### PR TITLE
Allow action refinement

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/agent/base/classes.py
+++ b/rocq-pipeline/src/rocq_pipeline/agent/base/classes.py
@@ -106,24 +106,28 @@ class ProofAgent(Agent):
             raise RuntimeError(f"{goal_ty_upperbound} is not a subclass of RocqGoal")
         self._goal_ty_upperbound = goal_ty_upperbound
 
-    def prove(self, rdm: RocqCursor) -> TaskResult:
+    def prepare(self, rdm: RocqCursor) -> None:
+        pass
+
+    def prove(self, rc: RocqCursor) -> TaskResult:
         """Prove the current goal using the restricted proof session.
 
         This method is called by run() after setting up a RocqProofSession.
         Subclasses should implement their proof logic here.
         """
-        return self.give_up(rdm, message="Not implemented")
+        return self.give_up(rc, message="Not implemented")
 
     @override
-    def run(self, rdm: RocqCursor) -> TaskResult:
+    def run(self, rc: RocqCursor) -> TaskResult:
         """Run the agent after ensuring there is a goal to prove."""
-        goal_reply = rdm.current_goal()
+        goal_reply = rc.current_goal()
         if goal_reply is None:
-            return self.finished(rdm, message="No goal to prove")
+            return self.finished(rc, message="No goal to prove")
         if isinstance(goal_reply, RocqCursor.Err):
-            return self.give_up(rdm, message="No goal to prove", reason=goal_reply)
+            return self.give_up(rc, message="No goal to prove", reason=goal_reply)
+        self.prove(rc)
         # TODO: validate that no goals remain.
-        return self.prove(rdm)
+        return self.prove(rc)
 
     def current_proof_state(
         self,

--- a/rocq-pipeline/src/rocq_pipeline/agent/proof/strategy_agent.py
+++ b/rocq-pipeline/src/rocq_pipeline/agent/proof/strategy_agent.py
@@ -1,29 +1,81 @@
+import itertools
+from dataclasses import dataclass
 from typing import override
 
 from rocq_doc_manager import RocqCursor
 
 from rocq_pipeline.agent import (
     TaskResult,
-    TraceAgent,
 )
+from rocq_pipeline.agent.base import ProofAgent
 from rocq_pipeline.agent.proof.strategy import Strategy
-from rocq_pipeline.proof_state import RocqGoal
+from rocq_pipeline.proof_state import ProofState, RocqGoal
 
 
-class StrategyAgent(TraceAgent):
+class StrategyAgent(ProofAgent):
     """An agent that uses a Strategy to select tactics."""
 
-    def __init__(self, strategy: Strategy) -> None:
+    def __init__(
+        self,
+        strategy: Strategy,
+        max_depth: int | None = None,
+        max_breath: int | None = None,
+        fuel: int | None = None,
+    ) -> None:
         super().__init__(goal_ty_upperbound=RocqGoal)
         self._strategy = strategy
-        self._rollout: Strategy.Rollout | None = None
+        self._max_depth = max_depth
+        self._max_breath = max_breath
+        self._fuel = fuel
+
+    def prepare(self, rc: RocqCursor) -> None:
+        pass
+
+    @dataclass
+    class NoProofState(Exception):
+        reason: RocqCursor.Err
+
+    def _current_state(self, rc: RocqCursor) -> ProofState:
+        reply = rc.current_goal()
+        if isinstance(reply, RocqCursor.Err):
+            raise StrategyAgent.NoProofState(reply)
+        return ProofState(reply)
 
     @override
-    def next_tac(self, rdm: RocqCursor) -> str | TaskResult:
-        if self._rollout is None or not self.last_failed():
-            self._rollout = self._strategy.rollout(rdm)
-        try:
-            _, action = next(self._rollout)
-            return action
-        except StopIteration:
-            return self.give_up(rdm, message="No more tactics in rollout after failure")
+    def prove(self, rc: RocqCursor) -> TaskResult:
+        self.prepare(rc)
+
+        depth: int = 0
+        rem_fuel: int | None = self._fuel
+        while True:
+            state = self._current_state(rc)
+            if state.closed(proof=True):
+                return self.finished(rc)
+
+            if self._max_depth is not None and depth >= self._max_depth:
+                return self.give_up(
+                    rc,
+                    message=f"depth limit exceeded({self._max_depth})",
+                )
+
+            rollout = self._strategy.rollout(rc)
+            for _, action in (
+                rollout
+                if self._max_breath is None
+                else itertools.islice(rollout, self._max_breath)
+            ):
+                if rem_fuel is not None:
+                    rem_fuel -= 1
+                    if rem_fuel <= 0:
+                        return self.give_up(rc, message=f"out of fuel ({self._fuel})")
+                action_rc = rc.clone()
+                if action.interact(action_rc):
+                    rc = action_rc
+                    depth += 1
+                    break
+                action_rc.dispose()
+            else:
+                # not executed if we see a break
+                return self.give_up(
+                    rc, f"No more proposals (max_breath={self._max_breath}"
+                )


### PR DESCRIPTION
This allows `Strategy`s to refine their actions based on immediate feedback from Rocq. This is slightly different than the alternative interactions that exist within `Strategy` because these refinements will be run sequentially rather than in parallel, i.e. the outer generator can be consumed in parallel, but any iteration within the `Action` will be done sequentially.

This should enable the LLM-based strategies to better implement the retry logic.


More documentation is almost certainly necessary, but opening for initial feedback.