### PR TITLE
Eliminate dynamic type error str vs. float

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/search/strategy.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/strategy.py
@@ -104,7 +104,7 @@ class CompositeStrategy[T_co](Strategy[T_co]):
 
                 # Lennart:  pr SOMETIMES is of dynamic type 'str', in which case the subsequent -pr
                 # operation raises the dynamic error 'bad operand type for unary - : str'
-                if type(pr) == str:
+                if isinstance(pr, str):
                     pr = float(pr)
                 heapq.heappush(queue, (-pr, i, act, gen))
 
@@ -120,7 +120,7 @@ class CompositeStrategy[T_co](Strategy[T_co]):
 
                 # Lennart:  pr SOMETIMES is of dynamic type 'str', in which case the subsequent -pr
                 # operation raises the dynamic error 'bad operand type for unary - : str'
-                if type(pr) == str:
+                if isinstance(pr, str):
                     pr = float(pr)
                 yield (-pr, act)
                 push_next(i, gen)


### PR DESCRIPTION
Implement the remedy suggested in issue https://github.com/SkyLabsAI/rocq-agent-toolkit/issues/39

There may well be a more pythonic way to resolve this (@jhaag-skylabs-ai ??) but the solution seems to avoid dynamic type errors in practice.