### PR TITLE
Added some print statements to ease tracing

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/search/rocq/actions.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/rocq/actions.py
@@ -26,7 +26,6 @@ class RocqTacticAction(Action[RocqCursor]):
         if isinstance(response, RocqCursor.Err):
             # Preserve the actual Rocq error message
             logger.info(f"  RocqTacticAction: '{self._tactic}' failed.")
-            # print(f"  RocqTacticAction: '{self._tactic}' failed.")
             raise Action.Failed(
                 message=response.message,
                 details=response,


### PR DESCRIPTION
To better understand how LLM calls and tactic invocations are orchestrated by ComposeStrategy this PR inserts (perhaps temporary) print statements at select places. This seems to be more useful for low-level debugging that loki/grafana/dashboard.