### PR TITLE
feat: add candidate generation protocols for search strategies

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/search/candidates/README.md
+++ b/rocq-pipeline/src/rocq_pipeline/search/candidates/README.md
@@ -1,0 +1,126 @@
+# Candidates Module (Layer 3)
+
+This module provides domain-agnostic abstractions for generating and correcting candidate actions during search.
+
+## Purpose
+
+The candidates layer bridges:
+- **Layer 0/1**: Generic search algorithms (Strategy, Action, BeamSearch)
+- **Layer 2**: Domain-specific execution (RocqTacticAction, LeanTacticAction)
+- **Application**: LLM-based or heuristic generators (live in backend repos)
+
+## Core Abstractions
+
+### `Candidate`
+
+A proposed action before execution. Domain-agnostic.
+
+```python
+@dataclass(frozen=True)
+class Candidate:
+    text: str        # "auto.", "e2e4", "rotate_90"
+    logprob: float   # Confidence from generator
+```
+
+### `CandidateGenerator`
+
+Generates candidates from state descriptions.
+
+```python
+class CandidateGenerator(Protocol):
+    def generate(self, state_desc: str, *, limit: int | None = None) -> Iterator[Candidate]:
+        """Yield candidates in descending probability order."""
+```
+
+### `CandidateRectifier`
+
+Corrects failed candidates based on error feedback.
+
+```python
+class CandidateRectifier(Protocol):
+    def rectify(self, state_desc: str, candidate: str, error: str) -> str | None:
+        """Return fixed candidate, or None if unfixable."""
+```
+
+### `GeneratorStrategy`
+
+Bridges generators to the Strategy interface.
+
+```python
+strategy = GeneratorStrategy(
+    generator=my_llm_generator,         # CandidateGenerator
+    get_state_desc=lambda c: c.goal(),  # Extract description
+    to_action=RocqTacticAction,         # Simple conversion
+    to_action_with_retry=RocqRetryAction,  # With rectification
+    rectifier=my_rectifier,
+    max_retries=3,
+)
+```
+
+## Usage Pattern
+
+### In rocq-agent-toolkit (Layer 3)
+
+Define protocols, no implementations:
+
+```python
+from rocq_pipeline.search.candidates import (
+    Candidate,
+    CandidateGenerator,
+    GeneratorStrategy,
+)
+```
+
+### In backend (Application)
+
+Implement generators and rectifiers:
+
+```python
+# brick_agents/proof/llm_generator.py
+
+class LLMTacticGenerator(CandidateGenerator):
+    def __init__(self, client: LLMClient, prompt_template: str):
+        self._client = client
+        self._template = prompt_template
+    
+    def generate(self, state_desc: str, *, limit: int | None = None):
+        prompt = self._template.format(goal=state_desc)
+        self._client.forward([{"role": "user", "content": prompt}])
+        
+        tactics = self._parse_response(self._client.content or "")
+        for i, tactic in enumerate(tactics[:limit]):
+            yield Candidate(text=tactic, logprob=-0.1 * i)
+```
+
+### Wiring it Together
+
+```python
+from rocq_pipeline.search.candidates import GeneratorStrategy
+from rocq_pipeline.search.rocq.actions import RocqTacticAction, RocqRetryAction
+
+strategy = GeneratorStrategy(
+    generator=LLMTacticGenerator(llm_client, PROMPT),
+    get_state_desc=lambda cursor: cursor.current_goal(),
+    to_action=RocqTacticAction,
+    to_action_with_retry=lambda t, r, n: RocqRetryAction(t, r, n),
+    rectifier=LLMTacticRectifier(llm_client),
+    max_retries=3,
+)
+
+# Use in search
+search = BeamSearch(strategy=strategy, ...)
+```
+
+## Why This Design?
+
+1. **Dependency inversion**: rocq-agent-toolkit defines protocols, backend implements them
+2. **Domain-agnostic**: Same `CandidateGenerator` can work for Rocq, Lean, games, puzzles
+3. **Composable**: Mix LLM generators with heuristic generators via `CompositeStrategy`
+4. **Testable**: Mock generators for testing without LLM calls
+
+## See Also
+
+- `search/strategy.py` - Strategy base class
+- `search/rocq/actions.py` - RocqRetryAction for rectification
+- Backend examples: `brick_agents/proof/strategy/`
+

--- a/rocq-pipeline/src/rocq_pipeline/search/candidates/__init__.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/candidates/__init__.py
@@ -1,0 +1,21 @@
+"""
+Layer 3: Candidate generation for proof search.
+
+This module provides protocols and adapters for generating and correcting
+candidate actions (tactics, moves, etc.) from state descriptions.
+Implementations (e.g., LLM-based generators) live in application code.
+"""
+
+from .core import (
+    Candidate,
+    CandidateGenerator,
+    CandidateRectifier,
+    GeneratorStrategy,
+)
+
+__all__ = [
+    "Candidate",
+    "CandidateGenerator",
+    "CandidateRectifier",
+    "GeneratorStrategy",
+]

--- a/rocq-pipeline/src/rocq_pipeline/search/candidates/core.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/candidates/core.py
@@ -1,0 +1,179 @@
+"""Core abstractions for candidate generation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Protocol
+
+from ..action import Action
+from ..strategy import Strategy
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """
+    A proposed action before execution.
+
+    Candidates are domain-agnostic strings that can be converted to
+    domain-specific Actions (e.g., Rocq tactics, Lean tactics, chess moves).
+    """
+
+    text: str
+    """The candidate action as a string (e.g., "auto.", "e2e4")."""
+
+    logprob: float = 0.0
+    """
+    Log probability from the generator.
+    Higher (less negative) = more confident.
+    """
+
+
+class CandidateGenerator(Protocol):
+    """
+    Generate candidate actions from a state description.
+
+    This is the integration point for LLM-based or heuristic candidate
+    generation. Implementations live in application code.
+
+    Examples:
+        - LLM tactic generator for theorem proving
+        - Move generator for games
+        - Transform generator for puzzles
+    """
+
+    def generate(
+        self,
+        state_desc: str,
+        *,
+        limit: int | None = None,
+    ) -> Iterator[Candidate]:
+        """
+        Generate candidates for the given state.
+
+        Args:
+            state_desc: String description of current state (goal, board, grid, etc.)
+            limit: Maximum number of candidates to generate
+
+        Yields:
+            Candidates in descending probability order (best first)
+        """
+        ...
+
+
+class CandidateRectifier(Protocol):
+    """
+    Rectify (correct) a failed candidate given error feedback.
+
+    Implementations typically use LLMs to fix syntax errors or
+    semantic issues based on error messages.
+    """
+
+    def rectify(
+        self,
+        state_desc: str,
+        candidate: str,
+        error: str,
+    ) -> str | None:
+        """
+        Attempt to fix a failed candidate.
+
+        Args:
+            state_desc: String description of current state
+            candidate: The candidate that failed
+            error: Error message from the failure
+
+        Returns:
+            Rectified candidate string, or None if unfixable
+        """
+        ...
+
+
+class GeneratorStrategy[StateT](Strategy[StateT]):
+    """
+    Strategy that uses a CandidateGenerator.
+
+    Bridges Layer 3 (domain-agnostic candidate generation) to
+    Layer 0 (domain-specific Strategy/Action execution).
+
+    Example:
+        >>> strategy = GeneratorStrategy(
+        ...     generator=my_llm_generator,
+        ...     get_state_desc=lambda cursor: cursor.current_goal(),
+        ...     to_action=RocqTacticAction,
+        ...     to_action_with_retry=lambda t, r, n: RocqRetryAction(t, r, n),
+        ...     rectifier=my_llm_rectifier,
+        ...     max_retries=3,
+        ... )
+    """
+
+    def __init__(
+        self,
+        generator: CandidateGenerator,
+        get_state_desc: Callable[[StateT], str | None],
+        to_action: Callable[[str], Action[StateT]],
+        to_action_with_retry: Callable[
+            [str, CandidateRectifier | None, int], Action[StateT]
+        ]
+        | None = None,
+        rectifier: CandidateRectifier | None = None,
+        max_retries: int = 0,
+    ) -> None:
+        """
+        Initialize a generator-based strategy.
+
+        Args:
+            generator: Produces candidates from state description
+            get_state_desc: Extracts string description from state (e.g., goal)
+                           Returns None if state is not applicable
+            to_action: Converts candidate text to executable Action (simple)
+            to_action_with_retry: Converts candidate to retry-capable Action
+                                 Signature: (text, rectifier, max_retries) -> Action
+                                 If None, rectification is disabled
+            rectifier: Optional rectifier for failed candidates
+            max_retries: Number of rectification attempts (0 = disabled)
+        """
+        self._generator = generator
+        self._get_state_desc = get_state_desc
+        self._to_action = to_action
+        self._to_action_with_retry = to_action_with_retry
+        self._rectifier = rectifier
+        self._max_retries = max_retries
+
+    def rollout(
+        self,
+        state: StateT,
+        max_rollout: int | None = None,
+        context: Strategy.Context | None = None,
+    ) -> Strategy.Rollout[StateT]:
+        """
+        Generate actions by converting candidates to domain-specific Actions.
+
+        Args:
+            state: Current domain state
+            max_rollout: Maximum number of actions to generate
+            context: Optional context (passed through, not used)
+
+        Yields:
+            (logprob, Action) pairs in descending probability order
+        """
+        state_desc = self._get_state_desc(state)
+        if state_desc is None:
+            return  # No description = no candidates
+
+        for candidate in self._generator.generate(state_desc, limit=max_rollout):
+            # Use retry-capable action if rectifier is enabled and available
+            if (
+                self._max_retries > 0
+                and self._rectifier is not None
+                and self._to_action_with_retry is not None
+            ):
+                action = self._to_action_with_retry(
+                    candidate.text,
+                    self._rectifier,
+                    self._max_retries,
+                )
+            else:
+                action = self._to_action(candidate.text)
+
+            yield (candidate.logprob, action)

--- a/rocq-pipeline/tests/rocq_pipeline/search/test_candidates.py
+++ b/rocq-pipeline/tests/rocq_pipeline/search/test_candidates.py
@@ -1,0 +1,235 @@
+"""Tests for candidate generation infrastructure."""
+
+from collections.abc import Iterator
+
+from rocq_pipeline.search.action import Action
+from rocq_pipeline.search.candidates import (
+    Candidate,
+    CandidateGenerator,
+    CandidateRectifier,
+    GeneratorStrategy,
+)
+
+# Test fixtures
+
+
+class DummyState:
+    def __init__(self, desc: str, solved: bool = False):
+        self.desc = desc
+        self.solved = solved
+
+
+class DummyAction(Action[DummyState]):
+    def __init__(self, text: str, should_fail: bool = False):
+        self._text = text
+        self._should_fail = should_fail
+
+    def interact(self, state: DummyState) -> DummyState:
+        if self._should_fail:
+            raise Action.Failed(f"Action '{self._text}' failed")
+        return DummyState(f"{state.desc} + {self._text}", self._text == "solve")
+
+    def key(self) -> str:
+        return self._text
+
+
+class SimpleGenerator(CandidateGenerator):
+    """Generator that returns fixed candidates."""
+
+    def __init__(self, candidates: list[tuple[str, float]]):
+        self._candidates = candidates
+
+    def generate(
+        self, state_desc: str, *, limit: int | None = None
+    ) -> Iterator[Candidate]:
+        items = self._candidates[:limit] if limit else self._candidates
+        for text, logprob in items:
+            yield Candidate(text=text, logprob=logprob)
+
+
+class SimpleRectifier(CandidateRectifier):
+    """Rectifier that fixes known errors."""
+
+    def __init__(self, fixes: dict[tuple[str, str], str]):
+        self._fixes = fixes  # (candidate, error) -> fixed
+
+    def rectify(self, state_desc: str, candidate: str, error: str) -> str | None:
+        return self._fixes.get((candidate, error))
+
+
+# Tests
+
+
+def test_candidate_creation():
+    """Test Candidate dataclass."""
+    c = Candidate(text="auto.", logprob=-0.5)
+    assert c.text == "auto."
+    assert c.logprob == -0.5
+
+
+def test_simple_generator():
+    """Test a simple candidate generator."""
+    gen = SimpleGenerator(
+        [
+            ("action1", -0.1),
+            ("action2", -0.2),
+            ("action3", -0.3),
+        ]
+    )
+
+    candidates = list(gen.generate("some state"))
+    assert len(candidates) == 3
+    assert candidates[0].text == "action1"
+    assert candidates[0].logprob == -0.1
+
+
+def test_generator_with_limit():
+    """Test generator respects limit parameter."""
+    gen = SimpleGenerator(
+        [
+            ("action1", -0.1),
+            ("action2", -0.2),
+            ("action3", -0.3),
+        ]
+    )
+
+    candidates = list(gen.generate("some state", limit=2))
+    assert len(candidates) == 2
+    assert candidates[1].text == "action2"
+
+
+def test_generator_strategy_basic():
+    """Test GeneratorStrategy with simple actions."""
+    gen = SimpleGenerator(
+        [
+            ("step1", -0.1),
+            ("step2", -0.2),
+        ]
+    )
+
+    strategy = GeneratorStrategy(
+        generator=gen,
+        get_state_desc=lambda s: s.desc,
+        to_action=lambda t: DummyAction(t),
+    )
+
+    state = DummyState("initial")
+    rollout = list(strategy.rollout(state, max_rollout=10))
+
+    assert len(rollout) == 2
+    assert rollout[0][0] == -0.1  # logprob
+    assert rollout[0][1].key() == "step1"
+    assert rollout[1][0] == -0.2
+    assert rollout[1][1].key() == "step2"
+
+
+def test_generator_strategy_no_state_desc():
+    """Test GeneratorStrategy when state has no description."""
+    gen = SimpleGenerator([("action", -0.1)])
+
+    strategy = GeneratorStrategy(
+        generator=gen,
+        get_state_desc=lambda s: None,  # No description
+        to_action=lambda t: DummyAction(t),
+    )
+
+    state = DummyState("any")
+    rollout = list(strategy.rollout(state))
+
+    assert len(rollout) == 0  # No candidates generated
+
+
+def test_generator_strategy_with_max_rollout():
+    """Test GeneratorStrategy respects max_rollout."""
+    gen = SimpleGenerator(
+        [
+            ("a1", -0.1),
+            ("a2", -0.2),
+            ("a3", -0.3),
+            ("a4", -0.4),
+        ]
+    )
+
+    strategy = GeneratorStrategy(
+        generator=gen,
+        get_state_desc=lambda s: s.desc,
+        to_action=lambda t: DummyAction(t),
+    )
+
+    state = DummyState("test")
+    rollout = list(strategy.rollout(state, max_rollout=2))
+
+    assert len(rollout) == 2
+
+
+def test_generator_strategy_with_retry():
+    """Test GeneratorStrategy with retry-capable actions."""
+    gen = SimpleGenerator([("action", -0.1)])
+    rectifier = SimpleRectifier({})
+
+    retry_action_called = False
+
+    def to_action_with_retry(text, rect, retries):
+        nonlocal retry_action_called
+        retry_action_called = True
+        assert text == "action"
+        assert rect is rectifier
+        assert retries == 3
+        return DummyAction(text)
+
+    strategy = GeneratorStrategy(
+        generator=gen,
+        get_state_desc=lambda s: s.desc,
+        to_action=lambda t: DummyAction(t),
+        to_action_with_retry=to_action_with_retry,
+        rectifier=rectifier,
+        max_retries=3,
+    )
+
+    state = DummyState("test")
+    rollout = list(strategy.rollout(state))
+
+    assert retry_action_called
+    assert len(rollout) == 1
+
+
+def test_generator_strategy_no_retry_when_disabled():
+    """Test GeneratorStrategy uses simple action when retry disabled."""
+    gen = SimpleGenerator([("action", -0.1)])
+
+    simple_action_called = False
+
+    def to_action(text):
+        nonlocal simple_action_called
+        simple_action_called = True
+        return DummyAction(text)
+
+    strategy = GeneratorStrategy(
+        generator=gen,
+        get_state_desc=lambda s: s.desc,
+        to_action=to_action,
+        to_action_with_retry=lambda t, r, n: DummyAction(t),
+        rectifier=SimpleRectifier({}),
+        max_retries=0,  # Disabled
+    )
+
+    state = DummyState("test")
+    list(strategy.rollout(state))
+
+    assert simple_action_called
+
+
+def test_simple_rectifier():
+    """Test SimpleRectifier fixes known errors."""
+    rectifier = SimpleRectifier(
+        {
+            ("broken", "Error: syntax"): "fixed",
+        }
+    )
+
+    result = rectifier.rectify("goal", "broken", "Error: syntax")
+    assert result == "fixed"
+
+    # Unknown error returns None
+    result = rectifier.rectify("goal", "broken", "Unknown error")
+    assert result is None


### PR DESCRIPTION
Adds the candidates module that bridges domain-agnostic candidate generation (e.g., LLM-based tactic generation) to the search infrastructure.

Key components:
- Candidate: Domain-agnostic proposed action with logprob (tactics for rocq)
- CandidateGenerator: Protocol for generating candidates from state descriptions
- CandidateRectifier: Protocol for correcting failed candidates
- GeneratorStrategy: Adapter that converts generators to Strategy.rollout()

This enables application code (e.g., brick_agents) to implement LLM-based generators without coupling the search infrastructure to specific LLM implementations or domains.