### PR TITLE
[rocq-pipeline] cleanup module exports and thread StrategyAgent.Context to rollout in StrategyAgent.prove

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/agent/base/classes.py
+++ b/rocq-pipeline/src/rocq_pipeline/agent/base/classes.py
@@ -106,9 +106,6 @@ class ProofAgent(Agent, VERSION="1.0.0"):
             raise RuntimeError(f"{goal_ty_upperbound} is not a subclass of RocqGoal")
         self._goal_ty_upperbound = goal_ty_upperbound
 
-    def prepare(self, rdm: RocqCursor) -> None:
-        pass
-
     def prove(self, rc: RocqCursor) -> TaskResult:
         """Prove the current goal using the restricted proof session.
 

--- a/rocq-pipeline/src/rocq_pipeline/agent/proof/__init__.py
+++ b/rocq-pipeline/src/rocq_pipeline/agent/proof/__init__.py
@@ -2,8 +2,8 @@ from .auto import AutoAgent
 from .choice import ChoiceAgent
 from .markov import MarkovAgent
 from .one_shot import OneShotAgent, OneShotBuilder
-from .search_agent import SearchAgent
 from .strategy_agent import StrategyAgent
+from .strategy_search import SearchAgent
 from .trace import TraceAgent
 from .trace_cursor import TracingCursor
 

--- a/rocq-pipeline/src/rocq_pipeline/search/strategy.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/strategy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import heapq
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from typing import Any, TypeVar, override
 
 from .action import Action
@@ -25,6 +25,7 @@ class Strategy[T_co](ABC):
     # for searches to work correctly. Clients should use an
     # implementation such as `immutabledict` to achieve this.
     # Mutable information needs to be tracked in the state
+    type MutableContext = MutableMapping[str, Any]
     type Context = Mapping[str, Any]
 
     @abstractmethod


### PR DESCRIPTION
Update `rocq_pipeline` to:
1. properly export all classes from `__init__.py` files in `rocq_pipeline/agent/`
2. update `Strategy` to include `Strategy.MutableContext` as a counterpart to `Strategy.Context`
3. update `StrategyAgent` to:
    - a) return `Strategy.MutableContext` from `prepare`
    - b) thread (a) to `self._strategy.rollout`