### PR TITLE
fix: fix SafeTacticStrategy for use in EStrategy

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/search/rocq/strategies.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/rocq/strategies.py
@@ -24,7 +24,7 @@ class SafeTacticStrategy(Strategy):
         context: Strategy.Context | None = None,
     ) -> Strategy.Rollout:
         return (
-            (prob, RocqTacticAction(f"progress {tac}"))
+            (prob, RocqTacticAction(f"progress ({tac})"))
             for prob, tac in [(self._prob, self._tactic)]
         )
 


### PR DESCRIPTION
SafeTacticStrategy must produce `progress (progress ework; match goal ...)` to ensure safety, but we produce `progress progress ework; match goal ...` instead, which means `(progress progress ework); match goal ...`.

I think @jhaag-skylabs-ai confirmed this in the meeting.