### PR TITLE
Correctly consume "Proof" at beginning of tasks

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/locator.py
+++ b/rocq-pipeline/src/rocq_pipeline/locator.py
@@ -70,7 +70,7 @@ class FirstLemma(Locator):
 
         if rdm.advance_to_first_match(is_lemma, step_over_match=True):
             for cmd in rdm.doc_suffix():
-                if cmd.kind == "blank" or (
+                if cmd.kind != "command" or (
                     cmd.kind == "command" and cmd.text.startswith("Proof")
                 ):
                     run_step_reply = rdm.run_step()


### PR DESCRIPTION
The correct key is to use "blanks" rather than "blank". This is now fixed.

It would be good if the type signature for this field said something like `Literal["blanks"] | Literal["command"]`, but the code is auto-generated.