### PR TITLE
doc(rocq-pipeline): mermaid diagrams for Strategy and Action

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/search/README.md
+++ b/rocq-pipeline/src/rocq_pipeline/search/README.md
@@ -40,11 +40,11 @@ An **Action** represents a single executable operation. The [`interact(state)`](
 **Key properties:**
 - **Explicit failure**: Uses exceptions rather than silent failures
 - **State transformation**: `interact(state) → new_state`
-- **Deduplication**: [`key()`](action.py) provides stable identifiers for repetition checks
+- **Deduplication**: [`key()`](action.py) provides stable identifiers to describe the action
 
 **Example implementations:**
 - [`RocqTacticAction`](../rocq/actions.py): Executes a single Rocq tactic
-- [`RocqRetryAction`](../rocq/actions.py): Adds LLM-based rectification on failure
+- [`RocqRetryAction`](../rocq/actions.py): Adds the ability to alter the tactic based on Rocq feedback
 
 ### Relationship
 

--- a/rocq-pipeline/src/rocq_pipeline/search/rocq/README.md
+++ b/rocq-pipeline/src/rocq_pipeline/search/rocq/README.md
@@ -43,18 +43,3 @@ class FirstTacticStrategy(Strategy):
     def rollout(self, rdm, ...):
         return ((prob, tac) for prob, tac in self._tactics)  # Yields Actions
 ```
-
-### Complete Example: Oracle Pattern
-
-[`OracleStrategy`](../../agent/proof/oracle_agent.py) and [`StepAction`](../../agent/proof/oracle_agent.py) show a complete strategy-action pair where the strategy creates domain-specific actions:
-
-```mermaid
-graph TD
-    OS[OracleStrategy] -->|rollout| SA[StepAction]
-    SA -->|interact| RC[RocqCursor]
-    RC -->|run_step| Result
-    Result -->|success| NewState
-    Result -->|failure| Action.Failed
-```
-
-See [`OracleAgent`](../../agent/proof/oracle_agent.py) for how this strategy is used in practice.


### PR DESCRIPTION
cf. https://github.com/SkyLabsAI/rocq-agent-toolkit/pull/97

- [x] add mermaid diagrams capturing the relationship between `Strategy`+`Action`+`Agent`
- [x] tweak existing `README.md` text to include more detail regarding:
  - [x] `Strategy`+`Action`, including how they are concretely used
  - [x] `Agent` <-> `Strategy`+`Action`, including how concrete agents can use results from `Strategy.rollout`