### PR TITLE
fix(search): apply explore_width per node in rollout expansion

### DIFF
--- a/rocq-pipeline/tests/rocq_pipeline/search/test_search_rollout.py
+++ b/rocq-pipeline/tests/rocq_pipeline/search/test_search_rollout.py
@@ -64,8 +64,8 @@ class QueueFrontier[T](Frontier[T, BasicNode[T]]):
         return [(x.state, x) for x in pulled]
 
 
-def test_explore_width_is_global_budget() -> None:
-    """Verify explore_width limits total actions across the beam per iteration."""
+def test_explore_width_is_per_node_budget() -> None:
+    """Verify explore_width limits actions per node per iteration."""
     record: list[str] = []
     actions: dict[int, list[tuple[float, Action[int]]]] = {
         0: [
@@ -82,7 +82,7 @@ def test_explore_width_is_global_budget() -> None:
 
     run_search(strategy, frontier, beam_width=2, explore_width=2)
 
-    assert record == ["c1_a1", "c1_a2"]
+    assert record == ["c1_a1", "c1_a2", "c2_a1", "c2_a2"]
 
 
 def test_repush_and_rollout_reuse() -> None:


### PR DESCRIPTION
I updated search.py so explore_width is applied per node rather than as a global cap across the whole beam step. Before, the rollout logic interleaved all nodes and only expanded explore_width total actions across the beam. Now each selected node consumes up to explore_width actions from its own cached rollout generator and is repushed afterward, so remaining actions are preserved for later steps.

Pruning behavior is unchanged (action de‑dup, repetition policy, frontier dedup), and the Strategy interface stays the same. This only increases per‑step expansion to at most beam_width × explore_width. 

beam width -> frontier
explore width per node expansion / new actions
if we have budget 2
frontier had 5 nodes, explore width was 2
    n1                        n2                          ...
n11 n12              n21 n22