### PR TITLE
Seaprate run_level information  from task-level in the JSONL

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/agent/base/dataclasses.py
+++ b/rocq-pipeline/src/rocq_pipeline/agent/base/dataclasses.py
@@ -102,12 +102,8 @@ class TaskResult:
     def to_task_output(
         self,
         *,
-        agent_cls_checksum: str,
-        agent_checksum: str,
-        run_id: str | None = None,
         task_kind: task_output.TaskKind | None = None,
         task_id: str | None = None,
-        dataset_id: str | None = None,
         timestamp_utc: str | None = None,
         trace_id: str | None = None,
         metadata: task_output.Metadata | None = None,
@@ -125,17 +121,10 @@ class TaskResult:
         else:
             status = task_output.TaskStatus(task_output.Failure())
 
-        if (
-            run_id is None
-            or task_kind is None
-            or task_id is None
-            or dataset_id is None
-            or timestamp_utc is None
-        ):
+        if task_kind is None or task_id is None or timestamp_utc is None:
             missing = [
                 k
                 for k, v in {
-                    "run_id": run_id,
                     "task_kind": task_kind,
                     "task_id": task_id,
                     "timestamp_utc": timestamp_utc,
@@ -145,14 +134,11 @@ class TaskResult:
             raise ValueError(f"Missing required fields: {', '.join(missing)}")
 
         return task_output.TaskOutput(
-            run_id=run_id,
+            type="task",
             task_kind=task_kind,
             task_id=task_id,
-            dataset_id=dataset_id,
             trace_id=trace_id,
             timestamp_utc=timestamp_utc,
-            agent_cls_checksum=agent_cls_checksum,
-            agent_checksum=agent_checksum,
             status=status,
             # TODO: remove `self.metrics` once opentelemetry instrumentation is in place
             metrics=self._metrics,

--- a/rocq-pipeline/src/rocq_pipeline/schema/task_output.atd
+++ b/rocq-pipeline/src/rocq_pipeline/schema/task_output.atd
@@ -44,25 +44,41 @@ type metrics <doc text="Aggregated metrics for task."> = {
 type tags <doc text="User-defined tags as key/value pairs."> = (string * string) list <python repr="dict"> <json repr="object">
 
 type metadata <doc text="Additional metadata for a task."> = {
-  ~tags <doc text="User-defined tags for this task (from environment, etc.).">
+  ~tags <doc text="User-defined tags for this task.">
     <python default="Tags({})"> : tags;
 }
 
-type task_output <doc text="Agent output for a single task."> = {
+type agent_class_info <doc text="Agent class provenance for the run."> = {
+  cls_checksum <doc text="Pseudo-unique checksum of the Agent class."> : string;
+  cls_name <doc text="Name of the Agent class."> : string;
+  cls_provenance <doc text="Provenance for the Agent class."> : abstract;
+}
+
+type agent_info <doc text="Agent instance provenance for the run."> = {
+  cls_checksum <doc text="Checksum of the Agent class for correlation."> : string;
+  checksum <doc text="Pseudo-unique checksum of the Agent instance."> : string;
+  name <doc text="Name of the Agent instance."> : string;
+  provenance <doc text="Provenance for the Agent instance."> : abstract;
+}
+
+type run_header <doc text="Run header entry for JSONL output."> = {
+  type <doc text="Entry type (run)."> : string;
   run_id <doc text="Unique identifier for the run (UUID)."> : string;
+  dataset_id <doc text="Unique name of the dataset on which agent is run."> : string;
+  tags <doc text="Run-level tags from the environment."> : tags;
+  agent_cls <doc text="Agent class provenance."> : agent_class_info;
+  agent <doc text="Agent instance provenance."> : agent_info;
+}
+
+type task_output <doc text="Agent output for a single task."> = {
+  type <doc text="Entry type (task)."> : string;
   task_kind <doc text="Kind of task."> : task_kind;
   task_id <doc text="Unique task identifier (file+task locator)."> : string;
-  dataset_id <doc text="Unique name of the dataset on which agent is run"> : string;
   ?trace_id <doc text="Unique trace identifier for corresponding opentelemetry output."> : string option;
   timestamp_utc <doc text="Timestamp when task began (ISO 8601)."> : string;
-  (* NOTE: in the future we may want to store additional metadata
-     for reproducibility/comparison purposes
-   *)
-  agent_cls_checksum <doc text="Pseudo-unique checksum of the Agent class that attempted the task."> : string;
-  agent_checksum <doc text="Pseudo-unique checksum of the Agent instance that attempted the task."> : string;
   status <doc text="Task status upon completion."> : task_status;
   ?failure_reason <doc text="Reason for task failure."> : failure_reason option;
   ~results <doc text="Agent results after task completion."> <python default="None"> : abstract;
   metrics <doc text="Aggregated metrics for task."> : metrics;
-  ?metadata <doc text="Additional metadata, including env tags."> : metadata option;
+  ?metadata <doc text="Additional metadata, including task tags."> : metadata option;
 }

--- a/rocq-pipeline/src/rocq_pipeline/schema/task_output.py
+++ b/rocq-pipeline/src/rocq_pipeline/schema/task_output.py
@@ -652,6 +652,146 @@ class Metadata:
 
 
 @dataclass
+class AgentClassInfo:
+    """Original type: agent_class_info = { ... }"""
+
+    cls_checksum: str
+    cls_name: str
+    cls_provenance: Any
+
+    @classmethod
+    def from_json(cls, x: Any) -> "AgentClassInfo":
+        if isinstance(x, dict):
+            return cls(
+                cls_checksum=_atd_read_string(x["cls_checksum"])
+                if "cls_checksum" in x
+                else _atd_missing_json_field("AgentClassInfo", "cls_checksum"),
+                cls_name=_atd_read_string(x["cls_name"])
+                if "cls_name" in x
+                else _atd_missing_json_field("AgentClassInfo", "cls_name"),
+                cls_provenance=(lambda x: x)(x["cls_provenance"])
+                if "cls_provenance" in x
+                else _atd_missing_json_field("AgentClassInfo", "cls_provenance"),
+            )
+        else:
+            _atd_bad_json("AgentClassInfo", x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res["cls_checksum"] = _atd_write_string(self.cls_checksum)
+        res["cls_name"] = _atd_write_string(self.cls_name)
+        res["cls_provenance"] = (lambda x: x)(self.cls_provenance)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> "AgentClassInfo":
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class AgentInfo:
+    """Original type: agent_info = { ... }"""
+
+    cls_checksum: str
+    checksum: str
+    name: str
+    provenance: Any
+
+    @classmethod
+    def from_json(cls, x: Any) -> "AgentInfo":
+        if isinstance(x, dict):
+            return cls(
+                cls_checksum=_atd_read_string(x["cls_checksum"])
+                if "cls_checksum" in x
+                else _atd_missing_json_field("AgentInfo", "cls_checksum"),
+                checksum=_atd_read_string(x["checksum"])
+                if "checksum" in x
+                else _atd_missing_json_field("AgentInfo", "checksum"),
+                name=_atd_read_string(x["name"])
+                if "name" in x
+                else _atd_missing_json_field("AgentInfo", "name"),
+                provenance=(lambda x: x)(x["provenance"])
+                if "provenance" in x
+                else _atd_missing_json_field("AgentInfo", "provenance"),
+            )
+        else:
+            _atd_bad_json("AgentInfo", x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res["cls_checksum"] = _atd_write_string(self.cls_checksum)
+        res["checksum"] = _atd_write_string(self.checksum)
+        res["name"] = _atd_write_string(self.name)
+        res["provenance"] = (lambda x: x)(self.provenance)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> "AgentInfo":
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class RunHeader:
+    """Original type: run_header = { ... }"""
+
+    type: str
+    run_id: str
+    dataset_id: str
+    tags: Tags
+    agent_cls: AgentClassInfo
+    agent: AgentInfo
+
+    @classmethod
+    def from_json(cls, x: Any) -> "RunHeader":
+        if isinstance(x, dict):
+            return cls(
+                type=_atd_read_string(x["type"])
+                if "type" in x
+                else _atd_missing_json_field("RunHeader", "type"),
+                run_id=_atd_read_string(x["run_id"])
+                if "run_id" in x
+                else _atd_missing_json_field("RunHeader", "run_id"),
+                dataset_id=_atd_read_string(x["dataset_id"])
+                if "dataset_id" in x
+                else _atd_missing_json_field("RunHeader", "dataset_id"),
+                tags=Tags.from_json(x["tags"])
+                if "tags" in x
+                else _atd_missing_json_field("RunHeader", "tags"),
+                agent_cls=AgentClassInfo.from_json(x["agent_cls"])
+                if "agent_cls" in x
+                else _atd_missing_json_field("RunHeader", "agent_cls"),
+                agent=AgentInfo.from_json(x["agent"])
+                if "agent" in x
+                else _atd_missing_json_field("RunHeader", "agent"),
+            )
+        else:
+            _atd_bad_json("RunHeader", x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res["type"] = _atd_write_string(self.type)
+        res["run_id"] = _atd_write_string(self.run_id)
+        res["dataset_id"] = _atd_write_string(self.dataset_id)
+        res["tags"] = (lambda x: x.to_json())(self.tags)
+        res["agent_cls"] = (lambda x: x.to_json())(self.agent_cls)
+        res["agent"] = (lambda x: x.to_json())(self.agent)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> "RunHeader":
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class ResourceExhaustion:
     """Original type: failure_reason = [ ... | ResourceExhaustion of ... | ... ]"""
 
@@ -744,13 +884,10 @@ class FailureReason:
 class TaskOutput:
     """Original type: task_output = { ... }"""
 
-    run_id: str
+    type: str
     task_kind: TaskKind
     task_id: str
-    dataset_id: str
     timestamp_utc: str
-    agent_cls_checksum: str
-    agent_checksum: str
     status: TaskStatus
     metrics: Metrics
     trace_id: Optional[str] = None
@@ -762,27 +899,18 @@ class TaskOutput:
     def from_json(cls, x: Any) -> "TaskOutput":
         if isinstance(x, dict):
             return cls(
-                run_id=_atd_read_string(x["run_id"])
-                if "run_id" in x
-                else _atd_missing_json_field("TaskOutput", "run_id"),
+                type=_atd_read_string(x["type"])
+                if "type" in x
+                else _atd_missing_json_field("TaskOutput", "type"),
                 task_kind=TaskKind.from_json(x["task_kind"])
                 if "task_kind" in x
                 else _atd_missing_json_field("TaskOutput", "task_kind"),
                 task_id=_atd_read_string(x["task_id"])
                 if "task_id" in x
                 else _atd_missing_json_field("TaskOutput", "task_id"),
-                dataset_id=_atd_read_string(x["dataset_id"])
-                if "dataset_id" in x
-                else _atd_missing_json_field("TaskOutput", "dataset_id"),
                 timestamp_utc=_atd_read_string(x["timestamp_utc"])
                 if "timestamp_utc" in x
                 else _atd_missing_json_field("TaskOutput", "timestamp_utc"),
-                agent_cls_checksum=_atd_read_string(x["agent_cls_checksum"])
-                if "agent_cls_checksum" in x
-                else _atd_missing_json_field("TaskOutput", "agent_cls_checksum"),
-                agent_checksum=_atd_read_string(x["agent_checksum"])
-                if "agent_checksum" in x
-                else _atd_missing_json_field("TaskOutput", "agent_checksum"),
                 status=TaskStatus.from_json(x["status"])
                 if "status" in x
                 else _atd_missing_json_field("TaskOutput", "status"),
@@ -801,13 +929,10 @@ class TaskOutput:
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
-        res["run_id"] = _atd_write_string(self.run_id)
+        res["type"] = _atd_write_string(self.type)
         res["task_kind"] = (lambda x: x.to_json())(self.task_kind)
         res["task_id"] = _atd_write_string(self.task_id)
-        res["dataset_id"] = _atd_write_string(self.dataset_id)
         res["timestamp_utc"] = _atd_write_string(self.timestamp_utc)
-        res["agent_cls_checksum"] = _atd_write_string(self.agent_cls_checksum)
-        res["agent_checksum"] = _atd_write_string(self.agent_checksum)
         res["status"] = (lambda x: x.to_json())(self.status)
         res["metrics"] = (lambda x: x.to_json())(self.metrics)
         if self.trace_id is not None:

--- a/rocq-pipeline/tests/test_strategy_agent.py
+++ b/rocq-pipeline/tests/test_strategy_agent.py
@@ -66,10 +66,19 @@ def test_strategy_agent_doc_interaction() -> None:
         # Read and parse the result
         with open(result_file, encoding="utf-8") as f:
             lines = [line for line in f if line.strip()]
-            assert len(lines) == 1, f"Expected 1 result line, found {len(lines)}"
+            assert len(lines) == 2, f"Expected 2 result lines, found {len(lines)}"
 
-            task_output_json = json.loads(lines[0])
+            run_header_json = json.loads(lines[0])
+            run_header_obj = task_output.RunHeader.from_json(run_header_json)
+            assert run_header_obj.type == "run", (
+                f"Expected run header, got type={run_header_obj.type}"
+            )
+
+            task_output_json = json.loads(lines[1])
             task_output_obj = task_output.TaskOutput.from_json(task_output_json)
+            assert task_output_obj.type == "task", (
+                f"Expected task output, got type={task_output_obj.type}"
+            )
 
         # Verify the task succeeded
         assert str(task_output_obj.status.value.kind) == "Success", (


### PR DESCRIPTION
Currently, the JSONL schema treats every item as a task_result. This forces us to repeat run-level metadata (like run_id, dataset_id, and agent_provenance) within every single task entry, often requiring prefixes like TASKS_ to distinguish between scopes. ( Like in the TAGS ) 

This PR introduces a dedicated run item type at the start of the JSONL file. By decoupling run-level information from individual tasks. 

we can also store provenance data once at the beginning of the file and read it directly, removing our dependency on TEMPO for t data ingestion endpoint. cc @jhaag-skylabs-ai 