### PR TITLE
singleton: drop default value from `score` argument, add test

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/search/rollout.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/rollout.py
@@ -107,7 +107,7 @@ class ConsRollout[T_co](Rollout[T_co]):
             return Rollout.Approx(logprob=self._logprob, result=self._value)
 
 
-def singleton[T_co](value: T_co, *, score: float = 0.0) -> Rollout[T_co]:
+def singleton[T_co](value: T_co, *, score: float) -> Rollout[T_co]:
     return ConsRollout(value, logprob=score, rest=empty_Rollout())
 
 

--- a/rocq-pipeline/tests/rocq_pipeline/search/test_rollout.py
+++ b/rocq-pipeline/tests/rocq_pipeline/search/test_rollout.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 from math import log
 
+import pytest
 from rocq_pipeline.search.rollout import (
     ApproximatingRollout,
     InterleaveRollout,
@@ -75,3 +76,15 @@ def test_interleave_rollout() -> None:
     assert ir.next(log(0.2)) == approx(log(0.1), None)
     assert ir.next(log(0.1)) == approx(log(0.1), 1)
     is_empty(ir)
+
+
+@pytest.mark.parametrize("value", [1, 2])
+@pytest.mark.parametrize("score", [float("inf"), 1, 0, -1, -float("inf")])
+@pytest.mark.parametrize("probe", [float("inf"), 1, 0, -1, -float("inf")])
+def test_singleton(value: int, score: float, probe: float) -> None:
+    r = singleton(value, score=score)
+    if score >= probe:
+        assert r.next(probe) == Rollout.Approx(logprob=score, result=value)
+        is_empty(r)
+    else:
+        assert r.next(probe) == Rollout.Approx(logprob=score, result=None)


### PR DESCRIPTION
# New description (from Paolo)

The default appears unused. If we remove it, we don't need to worry if it is
correct during debugging.

### Old description

This does part of the change in #128. But we should do a bit more to clean up the distinction between tactics and commands.