### PR TITLE
Allow standalone build of the project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ _pyenv/
 __pycache__
 *.egg-info
 .hypothesis
+/uv.lock
+/pyproject.toml
 
 # direnv
 .envrc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: all
+all: help
+
+.PHONY: help
+help:
+	@echo "Available Makefile targets:"
+	@echo "- prepare: Sets up a local uv workspace (enables standalone use)."
+	@echo "- clean: Removes the local uv workspace."
+
+pyproject.toml: pyproject.toml.disabled
+	cp $< $@
+
+.PHONY: prepare
+prepare: pyproject.toml
+
+.PHONY: clean
+clean:
+	rm -f pyproject.toml

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.17)
+(name rocq-agent-toolkit)

--- a/pyproject.toml.disabled
+++ b/pyproject.toml.disabled
@@ -1,0 +1,56 @@
+[project]
+name = "rocq-agent-toolkit"
+version = "0.1.0"
+description = "Rocq Agent Toolkit"
+requires-python = "~=3.13.0"
+
+[tool.uv.workspace]
+members = [
+    "ocaml-jsonrpc-tp/python",
+    "provenance-toolkit",
+    "rocq-pipeline",
+    "rocq-doc-manager/python",
+    "psi-agent",
+    "observability",
+    "dashboard/backend"
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py313"
+extend-exclude = ["build"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP"]
+ignore = ["E501"] # line too long, handled by formatter
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.mypy]
+python_version = "3.13"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
+disable_error_code = ["import-untyped"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+markers = [
+    "integration: marks tests as integration",
+    "slow: marks tests as slow",
+    "unit: marks tests as unit",
+]

--- a/rocq-fake-repl/bin/fake_repl_json.ml
+++ b/rocq-fake-repl/bin/fake_repl_json.ml
@@ -1,5 +1,3 @@
-open Yojson
-
 (** filters out [-topfile] *)
 let get_args argv : string list =
   let rec go i : string list =
@@ -14,11 +12,12 @@ let env key : Yojson.t =
   with Not_found -> `Null
 
 let _ =
-  let result : Yojson.t = Yojson.(
-    `Assoc [("args", `List (List.map (fun s -> `String s) (get_args Sys.argv)));
+  let result : Yojson.t =
+    `Assoc [
+      ("args", `List (List.map (fun s -> `String s) (get_args Sys.argv)));
       ("ROCQPATH", env "ROCQPATH");
       ("ROCQLIB", env "ROCQLIB");
-      ("OCAMLPATH", env "OCAMLPATH")]
-    )
+      ("OCAMLPATH", env "OCAMLPATH")
+    ]
   in
   Yojson.pretty_to_channel stdout result

--- a/rocq-goal-to-json/basic/theories/dune
+++ b/rocq-goal-to-json/basic/theories/dune
@@ -8,6 +8,5 @@
    -w -ambiguous-paths))
  (theories
   Stdlib Ltac2
-  skylabs.ltac2.extra
   skylabs_ai.ltac2_derive
   skylabs_ai.ltac2_json))

--- a/rocq-goal-to-json/basic/theories/goal_util.v
+++ b/rocq-goal-to-json/basic/theories/goal_util.v
@@ -1,6 +1,5 @@
-Require Import skylabs.ltac2.extra.extra.
 Require skylabs_ai.ltac2_json.JSON.
-Import Ltac2 Control.Notations Ltac2.Printf.
+Import Ltac2 Ltac2.Printf.
 
 Ltac2 goal_to_json (_ : unit) : JSON.t :=
   let to_string c := Message.to_string (fprintf "%t" c) in

--- a/rocq-goal-to-json/iris/theories/dune
+++ b/rocq-goal-to-json/iris/theories/dune
@@ -9,6 +9,5 @@
  (theories
   Stdlib Ltac2
   stdpp iris
-  skylabs.ltac2.extra
   skylabs_ai.ltac2_derive
   skylabs_ai.ltac2_json))

--- a/rocq-pipeline/examples/theories/dune
+++ b/rocq-pipeline/examples/theories/dune
@@ -7,10 +7,4 @@
 (include_subdirs qualified)
 (coq.theory
  (name skylabs.pipeline.test)
- (theories
-  Stdlib Ltac2
-  Lens Lens.Elpi
-  stdpp iris
-  Equations Equations.Prop Equations.Type
-  elpi elpi_elpi elpi.apps.locker elpi.apps.NES
-  ExtLib))
+ (theories Stdlib Ltac2))

--- a/rocq-term-deps/plugin/g_term_deps.mlg
+++ b/rocq-term-deps/plugin/g_term_deps.mlg
@@ -2,6 +2,8 @@ DECLARE PLUGIN "rocq-term-deps.plugin"
 
 {
 
+[@@@ocaml.warning "-27"]
+
 open Stdarg
 
 }


### PR DESCRIPTION
This makes it so that the project can be used independently of our workspace, after running `make prepare` (which sets up a local `uv` workspace). Note that this duplicates some code from https://github.com/SkyLabsAI/BRiCk/tree/main/ltac2-extra to avoid a dependency. This is only for internal use, and for functions that can probably be upstreamed to Rocq.

**Note:** if we want to enforce that this keeps building in a stand-alone way, we need to test this in CI.