### PR TITLE
Enable http/protobuf endpoint for Alloy

### DIFF
--- a/observability/docker_compose/docker-compose.rocq.yml
+++ b/observability/docker_compose/docker-compose.rocq.yml
@@ -14,7 +14,7 @@ services:
     restart: unless-stopped
     ports:
       - "4327:4317"   # OTLP gRPC
-      # - "4328:4318"   # OTLP HTTP - Observability Package uses GRPC
+      - "4328:4318"   # OTLP HTTP - Observability Package uses GRPC
       # - "12365:12345" # Alloy UI - If required
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Enable http/protobuf endpoint for Alloy, this is needed for inference_gateway. 

Ref: https://github.com/SkyLabsAI/psi-verifier/pull/1086