### PR TITLE
Revert "BugFix Strip trailing '.' from tactics in RocqTacticAction to handle clients that predict tactics with these periods. "

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/search/rocq/actions.py
+++ b/rocq-pipeline/src/rocq_pipeline/search/rocq/actions.py
@@ -115,8 +115,6 @@ class RocqTacticAction(Action[RocqCursor]):
         no_evar: bool = False,
     ) -> None:
         """The tactic must be a Rocq tactic, **not** a Rocq command. See discussion above."""
-        # NOTE: some clients supply tactics with a trailing '.' and we strip it here.
-        tactic = tactic.strip().rstrip(".")
         ensure_tactic(tactic)
         # NOTE: we place the `progress` first, then the match
         tactic = f"progress ({tactic})" if progress else tactic

--- a/rocq-pipeline/tests/rocq_pipeline/search/rocq/test_rocq_actions.py
+++ b/rocq-pipeline/tests/rocq_pipeline/search/rocq/test_rocq_actions.py
@@ -39,19 +39,10 @@ class TestRocqTacticAction:
         action = RocqTacticAction("reflexivity")
         assert action.key() == "reflexivity"
 
-    def test_normalize_whitespace_and_periods(self) -> None:
-        """Tactics with whitespace and trailing periods are normalized."""
-        # Test whitespace normalization
-        action1 = RocqTacticAction("  reflexivity  ")
-        assert action1.key() == "reflexivity"
-
-        # Test period stripping
-        action2 = RocqTacticAction("apply H.")
-        assert action2.key() == "apply H"
-
-        # Test both together
-        action3 = RocqTacticAction("  auto.  ")
-        assert action3.key() == "auto"
+    def test_reject_invalid_tactic(self) -> None:
+        with pytest.raises(AssertionError) as exc_info:
+            RocqTacticAction("  reflexivity  ")
+        print(exc_info.value)
 
 
 class TestRocqRetryAction:


### PR DESCRIPTION
Reverts SkyLabsAI/rocq-agent-toolkit#150

Ongoing discussion internally in https://chat.google.com/room/AAQAffk_fIs/2VbGUspgD5U/2VbGUspgD5U.

Current status, to my understanding:
- I understand this revert should eventually go in — it enforces the new distinction between tactics and commands
- however, this is blocked until clients are migrated to the new distinction
- there is no plan for the migration, so this MR is blocked (indefinitely).