### PR TITLE
Refactor task tag handling in run_task 

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/task_runner.py
+++ b/rocq-pipeline/src/rocq_pipeline/task_runner.py
@@ -275,7 +275,6 @@ def run_task(
                 "Missing project name in task file; cannot derive dataset_id."
             )
 
-
         task_tags = task_output.Tags(dict(tags.value))
         for task_tag in task.tags:
             task_tags.value.update({f"TASK_{task_tag}": task_tag})


### PR DESCRIPTION
When running tasks , task metadata tags in the JSONL output would “accumulate” tags from previously executed tasks. This produced incorrect per-task tag sets and (when ingested) polluted task tags in the DB.

Sample json for the third task : ( Notice multiple TASK_NumTactics ) 
```json
{"run_id": "d49966a9-1fbf-494a-b95a-b492db8113e4", "task_kind": "FullProofTask", "task_id": "examples/loopcorpus/test_ssridents.v#Lemma:test_ok", "dataset_id": "brick_groundtruth", "timestamp_utc": "2026-02-17T05:21:03.727778+00:00", "agent_cls_checksum": "5d43e81e1d8a7ea086c5ae57852f1e8d", "agent_checksum": "b116a344fb2dd84a7d3f74e4e4908561", "status": "Failure", "metrics": {"llm_invocation_count": 0, "token_counts": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}, "resource_usage": {"execution_time_sec": 0.0, "cpu_time_sec": 0.0, "gpu_time_sec": 0.0}, "custom": null}, "trace_id": "6813404d65ef1dd4d2772c1819d654d1", "failure_reason": ["ExecutionError", "ValueError('Missing required API key: OPENROUTER_API_KEY. Either set it in os.environ or use set_request_credentials() for thread-safe concurrent access.')"], "results": {"message": "ValueError('Missing required API key: OPENROUTER_API_KEY. Either set it in os.environ or use set_request_credentials() for thread-safe concurrent access.')", "side_effects": {}}, "metadata": {"tags": {"name": "Areeb", "TASK_wp_do_while-loopinv": "wp_do_while-loopinv", "TASK_case_decide": "case_decide", "TASK_subst": "subst", "TASK_cbn": "cbn", "TASK_NumTactics=11": "NumTactics=11", "TASK_lia": "lia", "TASK_proof": "proof", "TASK_go": "go", "TASK_verify_spec": "verify_spec", "TASK_assert": "assert", "TASK_qed": "qed", "TASK_UnmatchedTactics=['(*cbn; *) go', '+', '-', 'Unset SsrIdents', '{', '}']": "UnmatchedTactics=['(*cbn; *) go', '+', '-', 'Unset SsrIdents', '{', '}']", "TASK_clear": "clear", "TASK_assumption": "assumption", "TASK_bind_ren": "bind_ren", "TASK_NumTactics=43": "NumTactics=43", "TASK_trivial": "trivial", "TASK_rewrite": "rewrite", "TASK_NumTactics=6": "NumTactics=6", "TASK_UnmatchedTactics=['Unset SsrIdents', 'vc_split (bool_decide (_t_ + 1 < n)%Z)']": "UnmatchedTactics=['Unset SsrIdents', 'vc_split (bool_decide (_t_ + 1 < n)%Z)']"}}}
```

**cleanup DB:** 
I removed the incorrect task-tag links from the DB, then re-ingested tasks.yaml so each task now has the correct tags.


**Ingestion background (context)**
We ingest tasks + tags in two ways:
- From JSONL results: upsert task by task_id, then upsert/attach any tags found in the JSONL. This allows tags to grow over time if new tags appear in later runs.
- From task YAML (tasks.yaml): ingest the task list similarly (upsert task + attach tags from YAML), enabling task definitions/tags to be managed independently of JSONL runs. 

**Also:** 
We can also remove the old way of ingesting tasks / task_tags from the run jsonl results, if we can ensure that tasks/Any change in tasks (tags) must be first ingested, using the tasks.yaml before agent run