### PR TITLE
Refactor task status determination in build_graph function

### DIFF
--- a/dashboard/backend/src/backend/graph.py
+++ b/dashboard/backend/src/backend/graph.py
@@ -151,17 +151,6 @@ def build_rocq_cursor_graph(logs: list[LogEntry]) -> Graph:
     # Finding the Task Status By seeing the result and proof state
     last_node = list(graph.nodes.values())[-1]
     result = last_node.information.get("result", None)
-    if result is None:
-        graph.update_graph_information({"taskStatus": False})
-    else:
-        # Default to "NoProofState" string if key is missing to distinguish from explicit None/null value
-        proof_state = result.get("proof_state", "NoProofState")
-        if proof_state == "NoProofState":
-            graph.update_graph_information({"taskStatus": False})
-        elif proof_state is None:  # proof_state = null means no goals are left to prove
-            graph.update_graph_information({"taskStatus": True})
-        else:
-            graph.update_graph_information({"taskStatus": False})
 
     proof_script = _extract_proof_Script(graph.edges)
     graph.update_graph_information({"proofScript": proof_script})


### PR DESCRIPTION
The `result` field in Loki is now returned as a plain string instead of a JSON object.

Its current shape looks like this:

```
"result": "proof_state=ProofState(focused_goals=[], unfocused_goals=[], shelved_goals=0, given_up_goals=0) feedback_messages=[] globrefs_diff=GlobrefsDiff(removed_inductives=[], added_inductives=[], removed_constants=[], added_constants=[])"
```

Previously, we were accessing it using `result.get("proofState")`, which worked when `result` was a dictionary. Now that it’s a string, this causes the error:

```
Error building graph: 'str' object has no attribute 'get'
```

Ideally, the correct solution would be to deserialize this string back into a `CommandData` object (from `rocq_doc_manager_api`) so it can be handled properly.

However, since we were already retrieving `task_status` separately and the logic for extracting it from `result` was redundant I removed that portion of the logic altogether.
