### PR TITLE
[rocq-pipeline] add a `rat build-deps` subcommand for task files

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/build_deps.py
+++ b/rocq-pipeline/src/rocq_pipeline/build_deps.py
@@ -1,0 +1,24 @@
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Any
+
+from rocq_pipeline.tasks import TaskFile
+
+
+def mk_parser(parent: Any | None = None) -> ArgumentParser:
+    """Used in ./cli.py to expose a 'build-deps' subcommand of 'rat'."""
+    description = "Enumerate .vo build targets relative to cwd for a single task_file."
+    help = "Supply a path to a single task file and enumerate its .vo dependencies relative to cwd."
+    if parent:
+        parser = parent.add_parser("build-deps", description=description, help=help)
+    else:
+        parser = ArgumentParser(description=description)
+    parser.add_argument("task_file", type=Path, help="The path to a single task file")
+    return parser
+
+
+def run_ns(arguments: Namespace, extra_args: list[str] | None = None) -> None:
+    """Used in ./cli.py to expose a 'build-deps' subcommand of 'rat'."""
+    assert extra_args is None or len(extra_args) == 0
+    taskfile = TaskFile.from_file(arguments.task_file)
+    print(" ".join([str(vo_path) for vo_path in taskfile.build_deps()]))

--- a/rocq-pipeline/src/rocq_pipeline/cli.py
+++ b/rocq-pipeline/src/rocq_pipeline/cli.py
@@ -2,7 +2,14 @@ from argparse import ArgumentParser, Namespace
 from collections.abc import Callable
 from typing import Any
 
-from rocq_pipeline import find_tasks, service_cli, task_manip, task_runner, tracer
+from rocq_pipeline import (
+    build_deps,
+    find_tasks,
+    service_cli,
+    task_manip,
+    task_runner,
+    tracer,
+)
 from rocq_pipeline.args_util import split_args
 
 # TODO: cleanup these type annotations
@@ -12,6 +19,7 @@ type mk_parserT[PARSER] = Callable[[Any | None], Any]
 type run_nsT = Callable[[Namespace, list[str] | None], Any]
 _entrypoints: dict[str, tuple[mk_parserT[Any], run_nsT]] = {
     "ingest": (find_tasks.mk_parser, find_tasks.run_ns),
+    "build-deps": (build_deps.mk_parser, build_deps.run_ns),
     "run": (
         lambda subparsers: task_runner.mk_parser(subparsers, with_agent=True),
         task_runner.run_ns,

--- a/rocq-pipeline/src/rocq_pipeline/tasks.py
+++ b/rocq-pipeline/src/rocq_pipeline/tasks.py
@@ -4,7 +4,7 @@ import copy
 import json
 import os
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Set
 from pathlib import Path
 from typing import Any, Literal
 
@@ -139,6 +139,10 @@ class TaskBundle(BaseModel):
     project: Project = Field(description="The Project that the tasks belong to.")
     tasks: list[Task] = Field(description="The Tasks in the project.")
 
+    def build_deps(self) -> Set[Path]:
+        """Enumerate the set of .vo dependencies for tasks in the project."""
+        return {self.project.path / task.file.with_suffix(".vo") for task in self.tasks}
+
     @field_serializer("tasks")
     def serialize_tasks(self, tasks: list[Task]):
         return sorted(tasks, key=lambda t: (t.file, t.name, str(t.locator)))
@@ -186,6 +190,14 @@ class TaskFile(BaseModel):
     project_bundles: list[TaskBundle] = Field(
         description="Bundles of projects and their associatd tasks"
     )
+
+    def build_deps(self) -> Set[Path]:
+        """Enumerate the .vo dependencies for all project_bundles."""
+        targets: set[Path] = set()
+        for project_bundle in self.project_bundles:
+            targets |= project_bundle.build_deps()
+
+        return targets
 
     @model_validator(mode="after")
     def merge_bundles(self) -> TaskFile:


### PR DESCRIPTION
## Background

Task files for agents contain references to `.v` files from projects. However, there is no programmatic way to generate the precise `.vo` dependencies that must be built.

**This PR introduces a `rat build-deps` subcommand that accepts a file-path to a task file and prints space-separated `.vo` file paths; the intended use case is, e.g., `dune build $(uv run rat build-deps path/to/task/file.yaml)`.**

## Changes

  - `cli.py`: add `build-deps` subcommand; implemented via `tasks.py` changes described below
  - `tasks.py`:
    - add `build_deps` methods to `TaskBundle` + `TaskFile`, returning `.vo` filepaths for dependencies of `TaskBundle` + `TaskFile`
    - add `TaskFile.cli_build_mk_parser` + `TaskFile.cli_build_run_ns` methods