### PR TITLE
[rocq-dune-util] Support plugins based on opam packages.

### DIFF
--- a/rocq-dune-util/src/rocq_dune_util/__init__.py
+++ b/rocq-dune-util/src/rocq_dune_util/__init__.py
@@ -8,6 +8,8 @@ the ability to query dune for Rocq CLI arguments for a Rocq source file.
 
 from .rocq_dune_util import (
     DuneError,
+    DuneRocqPlugin,
+    DuneRocqPluginNotFound,
     dune_build,
     dune_env_hack,
     dune_sourceroot,
@@ -16,6 +18,8 @@ from .rocq_dune_util import (
 
 __all__ = [
     "DuneError",
+    "DuneRocqPlugin",
+    "DuneRocqPluginNotFound",
     "dune_build",
     "dune_env_hack",
     "dune_sourceroot",


### PR DESCRIPTION
This will certainly help with https://github.com/SkyLabsAI/rocq-agent-toolkit/pull/173, as it provides a better interface.

The idea of the approach is as follows:
- A plugin is specified as the name of an opam package, plus list of Rocq source files relative to the package's directory as they would appear in the workspace.
- When resolving, we locate the workspace root, and look for file `PACKAGE_NAME.opam`.
- If it exists, then we can easily compute relative paths to the plugin's entry points from the workspace root.
- If it doesn't, then we check that the package is installed, and if so we don't need to do anything (in the future this might require a `-package` Rocq argument).

Example of plugin declarations:
```
rocq_goal_to_json = DuneRocqPlugin(
    opam_pkg="rocq-goal-to-json",
    entry_points=["basic/theories/goal_util.v"]
)

rocq_goal_to_json_iris = DuneRocqPlugin(
    opam_pkg="rocq-goal-to-json_iris",
    entry_points=["iris/theories/goal_util.v"]
)
```