### PR TITLE
[rocq-split] Include final blanks.

### DIFF
--- a/ocaml-rocq-split/lib/rocq_split/rocq_split.ml
+++ b/ocaml-rocq-split/lib/rocq_split/rocq_split.ml
@@ -211,6 +211,11 @@ let commands_data file cmds =
     add_command cmd loc (Buffer.contents buf)
   in
   List.iter handle_cmd cmds;
+  let _ =
+     match In_channel.input_all ic with
+     | ""   -> ()
+     | text -> add_blanks text !cur_offset (!cur_offset + String.length text)
+  in
   List.rev !rev_items
 
 let parse stream =

--- a/ocaml-rocq-split/tests/basic.t
+++ b/ocaml-rocq-split/tests/basic.t
@@ -14,6 +14,7 @@
   >   intro x.
   >   reflexivity.
   > Qed.
+  > 
   > EOF
 
   $ rocq_split -Q . test.dir test.v
@@ -64,6 +65,7 @@
         "ep": 185
       },
       { "kind": "blanks", "text": "\n", "bp": 185, "ep": 186 },
-      { "kind": "synpure:EndProof", "text": "Qed.", "bp": 186, "ep": 190 }
+      { "kind": "synpure:EndProof", "text": "Qed.", "bp": 186, "ep": 190 },
+      { "kind": "blanks", "text": "\n\n", "bp": 190, "ep": 192 }
     ]
   }

--- a/rocq-doc-manager/python/tests/test_api.py
+++ b/rocq-doc-manager/python/tests/test_api.py
@@ -37,6 +37,7 @@ class Test_API(RDM_Tests):
             rdm_api.SuffixItem(kind="command", text="reflexivity."),
             rdm_api.SuffixItem(kind="blanks", text="\n"),
             rdm_api.SuffixItem(kind="command", text="Qed."),
+            rdm_api.SuffixItem(kind="blanks", text="\n"),
         ]
 
     async def test_Check_query_text(
@@ -122,6 +123,10 @@ class Test_API(RDM_Tests):
                 rdm_api.SuffixItem(
                     text="Qed.",
                     kind="command",
+                ),
+                rdm_api.SuffixItem(
+                    text="\n",
+                    kind="blanks",
                 ),
             ]
 

--- a/rocq-doc-manager/tests/advance.t
+++ b/rocq-doc-manager/tests/advance.t
@@ -14,9 +14,9 @@
   > advance_to [0,4]
   > advance_to [0,4]
   > doc_suffix [0]
-  > advance_to [0,9]
-  > doc_suffix [0]
   > advance_to [0,10]
+  > doc_suffix [0]
+  > advance_to [0,11]
   > EOF
 
   $ cat calls.txt | jsonrpc-tp.build_requests | jsonrpc-tp.tp_wrap > commands.txt
@@ -34,7 +34,8 @@
       { "kind": "blanks", "text": "\n" },
       { "kind": "command", "text": "Definition n6 : nat := 6." },
       { "kind": "blanks", "text": "\n" },
-      { "kind": "command", "text": "Definition n8 : nat := 8." }
+      { "kind": "command", "text": "Definition n8 : nat := 8." },
+      { "kind": "blanks", "text": "\n" }
     ]
   }
   { "id": 5, "jsonrpc": "2.0", "result": null }

--- a/rocq-doc-manager/tests/basic.t
+++ b/rocq-doc-manager/tests/basic.t
@@ -44,6 +44,7 @@
   > run_step [0]
   > run_step [0]
   > run_step [0]
+  > run_step [0]
   > non-existent [0]
   > commit [0,null,false,true]
   > compile [0]
@@ -140,7 +141,8 @@
       { "kind": "blanks", "text": "\n  " },
       { "kind": "command", "text": "reflexivity." },
       { "kind": "blanks", "text": "\n" },
-      { "kind": "command", "text": "Qed." }
+      { "kind": "command", "text": "Qed." },
+      { "kind": "blanks", "text": "\n" }
     ]
   }
   { "id": 14, "jsonrpc": "2.0", "result": null }
@@ -197,8 +199,9 @@
       "globrefs_diff": { "added_constants": [ "test.dir.test.test" ] }
     }
   }
+  { "id": 24, "jsonrpc": "2.0", "result": null }
   {
-    "id": 24,
+    "id": 25,
     "jsonrpc": "2.0",
     "error": {
       "code": -32602,
@@ -206,13 +209,13 @@
     }
   }
   {
-    "id": 25,
+    "id": 26,
     "jsonrpc": "2.0",
     "error": { "code": -32601, "message": "Method non-existent not found." }
   }
-  { "id": 26, "jsonrpc": "2.0", "result": null }
+  { "id": 27, "jsonrpc": "2.0", "result": null }
   {
-    "id": 27,
+    "id": 28,
     "jsonrpc": "2.0",
     "result": {
       "success": true,

--- a/rocq-doc-manager/tests/cursor.t
+++ b/rocq-doc-manager/tests/cursor.t
@@ -23,6 +23,8 @@
   > cursor_index [0]
   > run_step [0]
   > cursor_index [0]
+  > run_step [0]
+  > cursor_index [0]
   > EOF
 
   $ cat calls.txt | jsonrpc-tp.build_requests | jsonrpc-tp.tp_wrap > commands.txt
@@ -63,12 +65,14 @@
     }
   }
   { "id": 13, "jsonrpc": "2.0", "result": 5 }
+  { "id": 14, "jsonrpc": "2.0", "result": null }
+  { "id": 15, "jsonrpc": "2.0", "result": 6 }
   {
-    "id": 14,
+    "id": 16,
     "jsonrpc": "2.0",
     "error": {
       "code": -32602,
       "message": "Invalid parameters for method run_step: no step left to run."
     }
   }
-  { "id": 15, "jsonrpc": "2.0", "result": 5 }
+  { "id": 17, "jsonrpc": "2.0", "result": 6 }

--- a/rocq-doc-manager/tests/revert.t
+++ b/rocq-doc-manager/tests/revert.t
@@ -21,6 +21,7 @@
   > run_step [0]
   > run_step [0]
   > run_step [0]
+  > run_step [0]
   > revert_before [0,{erase:false,index:0}]
   > revert_before [0,{erase:false,index:0}]
   > EOF
@@ -38,7 +39,8 @@
       { "kind": "blanks", "text": "\n" },
       { "kind": "command", "text": "About nat." },
       { "kind": "blanks", "text": "\n" },
-      { "kind": "command", "text": "Check test." }
+      { "kind": "command", "text": "Check test." },
+      { "kind": "blanks", "text": "\n" }
     ]
   }
   {
@@ -100,7 +102,8 @@
     "jsonrpc": "2.0",
     "result": [
       { "kind": "blanks", "text": "\n" },
-      { "kind": "command", "text": "Check test." }
+      { "kind": "command", "text": "Check test." },
+      { "kind": "blanks", "text": "\n" }
     ]
   }
   { "id": 11, "jsonrpc": "2.0", "result": null }
@@ -113,8 +116,9 @@
       ]
     }
   }
+  { "id": 13, "jsonrpc": "2.0", "result": null }
   {
-    "id": 13,
+    "id": 14,
     "jsonrpc": "2.0",
     "error": {
       "code": -32602,
@@ -122,7 +126,7 @@
     }
   }
   {
-    "id": 14,
+    "id": 15,
     "jsonrpc": "2.0",
     "error": {
       "code": -32602,
@@ -130,7 +134,7 @@
     }
   }
   {
-    "id": 15,
+    "id": 16,
     "jsonrpc": "2.0",
     "error": {
       "code": -32602,

--- a/rocq-pipeline/tests/prover.t/run.t
+++ b/rocq-pipeline/tests/prover.t/run.t
@@ -81,4 +81,4 @@
   
   Lemma forty_two_is_57 : forty_two = 57.
   Proof.
-  Admitted. (no-eol)
+  Admitted.


### PR DESCRIPTION
Fixes the issue identified in https://github.com/SkyLabsAI/rocq-agent-toolkit/pull/220.

There is probably gonna be breakage in python tests, but let's see.