### PR TITLE
fix(rocq-pipeline): revise handling of unfocused_goals in ProofState.closed

### DIFF
--- a/rocq-pipeline/src/rocq_pipeline/proof_state/__init__.py
+++ b/rocq-pipeline/src/rocq_pipeline/proof_state/__init__.py
@@ -118,9 +118,7 @@ class ProofState:
             - proof=False: True iff focused goals are closed; shelved/admitted/unfocused goals may remain
             - proof=True: True iff focused goals /and/ shelved/admitted/unfocused goals are closed
         """
-        focused_closed = (
-            len(self._focused_goals) == 0
-        )
+        focused_closed = len(self._focused_goals) == 0
         unfocused_closed = (
             # Note: unfocused_goals is a stack of remaining-goal counts
             not any(self._unfocused_goals)


### PR DESCRIPTION
`unfocused_goals` is actually a stack of remaining-goal counts, not a list of goal identifiers. This means that `ProofState.closed(proof=True)` should be checking for non-zero values in this list instead of asserting that the list is empty.