### PR TITLE
Show tactics proposed by the remote agent

### DIFF
--- a/rocq-doc-manager/python/src/rocq_doc_manager/rocq_cursor_websocket.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/rocq_cursor_websocket.py
@@ -227,6 +227,16 @@ class CursorDispatcher(Dispatcher):
         self, method: str, args: list[Any], kwargs: dict[str, Any]
     ) -> Any:
         (cursor, args) = self.extract_cursor(args)
+
+        # Print commands/tactics as they arrive over the websocket RPC boundary.
+        # Useful in remote-agent setups where the client otherwise waits for a
+        # final `control/run` response.
+        if method in {"insert_command", "_insert_command", "run_command"}:
+            text = args[0] if args else None
+            ghost = bool(kwargs.get("ghost", False))
+            if isinstance(text, str) and not ghost:
+                print(f"{text}", flush=True)
+
         match method:
             case "clone":
 

--- a/rocq-pipeline/src/rocq_pipeline/prover.py
+++ b/rocq-pipeline/src/rocq_pipeline/prover.py
@@ -28,6 +28,7 @@ async def run_proving_agent(
         print(f"Found admit at index {await main_rc.cursor_index()}.")
         for i, g in enumerate(goal.focused_goals):
             print(f"Goal {i}:{g.replace('\n', '\n  ')}")
+        print("\n")
         agent = agent_cls()  # Build the actual agent to run
         local_rc = await main_rc.clone()  # should materialize this
         task_result = await agent.run(rc=local_rc)


### PR DESCRIPTION
In the long run, we need more status message from the remote agent but currently showing the tactics being proposed seems sufficient. 



```
Running the proving agent.

Found admit at index 8.
Goal 0:
  ============================
  forall a : my_nat, my_add MyO a = a


#[local] Unset SsrIdents.
#[local] Set Default Goal Selector "1".
verify_spec; go.
intros a.
simpl.
reflexivity.
Qed.
Agent succeeded.
```
