### PR TITLE
Bug fixes in jsonrcp_tp

### DIFF
--- a/ocaml-jsonrpc-tp/python/src/jsonrpc_tp/jsonrpc_tp_async.py
+++ b/ocaml-jsonrpc-tp/python/src/jsonrpc_tp/jsonrpc_tp_async.py
@@ -212,11 +212,13 @@ class AsyncJsonRPCTP(AsyncProtocol):
             while True:
                 packet = await self._recv()
 
-                if "error" in packet or "result" in packet:
-                    await self._handle_response(packet)
-                elif isinstance(packet, list):
+                if isinstance(packet, list):
                     for response in packet:
                         await self._handle_response(response)
+                elif isinstance(packet, dict) and (
+                    "error" in packet or "result" in packet
+                ):
+                    await self._handle_response(packet)
                 else:
                     await self._handle_notification(packet)
         except asyncio.CancelledError:


### PR DESCRIPTION
Several small bug fixes in the library.

The first and second were caught by expanded type checking. The last is just extra hardening.

The second one is not necessarily an error because we catch `Exception`, but probably still better to fix.