### PR TITLE
Implementation of `modify_suffix`

### DIFF
--- a/rocq-doc-manager/README.md
+++ b/rocq-doc-manager/README.md
@@ -293,6 +293,18 @@ API Methods
 - Error payload: a `null` value.
 - Failure mode: recoverable failure.
 
+### `modify_suffix`
+
+- Description: modify the suffix of the document.
+- Arguments (in order, or named):
+  - `cursor`: the cursor to perform the operation on (as an integer).
+  - `index`: the index of the insertion point (as an integer).
+  - `count`: the number of items to remove (as an integer).
+  - `items`: the items to insert (as a list where each element is an instance of the `SuffixItem` object).
+- Response payload: a list where each element is an instance of the `Sentence` object.
+- Error payload: an instance of the `SentenceSplitError` object.
+- Failure mode: recoverable failure.
+
 ### `query`
 
 - Description: runs the given query at the cursor, not updating the state.

--- a/rocq-doc-manager/README.md
+++ b/rocq-doc-manager/README.md
@@ -129,6 +129,12 @@ API Objects
 - Field `offset`: an integer.
 - Field `kind`: any of `"blanks"`, `"command"`, `"ghost"`.
 
+### `UnprocessedItem`
+
+- Description: an unprocessed item, to be inserted.
+- Field `text`: a string.
+- Field `kind`: any of `"blanks"`, `"command"`, `"ghost"`.
+
 ### `SuffixItem`
 
 - Description: document suffix item, appearing after the cursor.
@@ -300,7 +306,7 @@ API Methods
   - `cursor`: the cursor to perform the operation on (as an integer).
   - `index`: the index of the insertion point (as an integer).
   - `count`: the number of items to remove (as an integer).
-  - `items`: the items to insert (as a list where each element is an instance of the `SuffixItem` object).
+  - `items`: the items to insert (as a list where each element is an instance of the `UnprocessedItem` object).
 - Response payload: a list where each element is an instance of the `Sentence` object.
 - Error payload: an instance of the `SentenceSplitError` object.
 - Failure mode: recoverable failure.

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -629,6 +629,17 @@ let _ =
     ~ret:S.(list (obj prefix_item)) @@ fun d () ->
   List.rev (Document.rev_prefix d)
 
+let tagged_item =
+  let fields =
+    API.Fields.add ~name:"kind" item_kind @@
+    API.Fields.add ~name:"text" S.string @@
+    API.Fields.nil
+  in
+  let encode (kind, (text, ())) = (text, kind) in
+  let decode _ = assert false in
+  API.declare_object api ~name:"UnprocessedItem" ~descr:"an unprocessed item, \
+    to be inserted" ~encode ~decode fields
+
 let suffix_item =
   let fields =
     API.Fields.add ~name:"kind" item_kind @@
@@ -740,14 +751,14 @@ let _ =
   let args =
     A.add ~name:"index" ~descr:"the index of the insertion point" S.int @@
     A.add ~name:"count" ~descr:"the number of items to remove" S.int @@
-    A.add ~name:"items" ~descr:"the items to insert" S.(list (obj suffix_item)) @@
+    A.add ~name:"items" ~descr:"the items to insert" S.(list (obj tagged_item)) @@
     A.nil
   in
   declare_full ~name:"modify_suffix" ~descr:"modify the suffix of the document"
     ~args ~ret:(S.list (S.obj sentence)) ~err:(S.obj sentence_split_error) @@ fun d (index,(count,(items, ()))) ->
     match Document.modify_suffix ~index ~count items d with
-    | Ok(sentences) -> Ok(sentences)
-    | Error(msg, (sentences, err)) -> Error(msg, (sentences, (err, ())))
+    | sentences, Ok(()) -> Ok(sentences)
+    | sentences, Error(msg, err) -> Error(msg, (sentences, (err, ())))
 
 
 let _ =

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -737,6 +737,20 @@ let _ =
   Result.map_error (fun s -> (s, ())) res
 
 let _ =
+  let args =
+    A.add ~name:"index" ~descr:"the index of the insertion point" S.int @@
+    A.add ~name:"count" ~descr:"the number of items to remove" S.int @@
+    A.add ~name:"items" ~descr:"the items to insert" S.(list (obj suffix_item)) @@
+    A.nil
+  in
+  declare_full ~name:"modify_suffix" ~descr:"modify the suffix of the document"
+    ~args ~ret:(S.list (S.obj sentence)) ~err:(S.obj sentence_split_error) @@ fun d (index,(count,(items, ()))) ->
+    match Document.modify_suffix ~index ~count items d with
+    | Ok(sentences) -> Ok(sentences)
+    | Error(msg, (sentences, err)) -> Error(msg, (sentences, (err, ())))
+
+
+let _ =
   declare_full ~name:"materialize" ~descr:"materializes the cursor, \
     giving it its own dedicated top-level" ~args:A.nil ~ret:S.null ~err:S.null
     @@ fun d () ->

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -456,7 +456,8 @@ let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in
   whitespace_required d.rev_prefix
 
-let modify_suffix : index:int -> count:int -> unprocessed_item list -> t -> (sentence list, string * string) result
+let modify_suffix : index:int -> count:int -> unprocessed_item list -> t ->
+  (sentence list, string * (sentence list * string)) result
   = fun ~index ~count sentences d ->
   let _ = get_backend d in
   let len_prefix = cursor_index d in
@@ -471,7 +472,7 @@ let modify_suffix : index:int -> count:int -> unprocessed_item list -> t -> (sen
     let text_for (ui : unprocessed_item) = ui.text in
     split_sentences d ~text:(String.concat "" @@ List.map text_for new_suffix) in
   match result with
-  | Error err -> Error(err)
+  | Error((a,b)) -> Error(a, (sentences, b))
   | Ok(()) ->
     d.suffix <- new_suffix;
     Ok(sentences)

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -456,17 +456,25 @@ let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in
   whitespace_required d.rev_prefix
 
-let modify_suffix : index:int -> count:int -> unprocessed_item list -> t -> unit = fun ~index ~count sentences d ->
+let modify_suffix : index:int -> count:int -> unprocessed_item list -> t -> (sentence list, string * string) result
+  = fun ~index ~count sentences d ->
   let _ = get_backend d in
   let len_prefix = cursor_index d in
   if index < len_prefix then raise (Invalid_argument "index occurs in prefix");
   let len_suffix = List.length d.suffix in
   if len_prefix + len_suffix < index + count then raise (Invalid_argument "range extends beyond end of suffix");
   let suff_offset = index - len_prefix in
-  let new_suffix =
-    List.concat [List.take suff_offset d.suffix; sentences; List.drop (suff_offset + count) d.suffix] in
-  assert false
-
+  let new_suffix: unprocessed_item list =
+      List.concat [List.take suff_offset d.suffix; sentences; List.drop (suff_offset + count) d.suffix] in
+  let sentences, result =
+    (* the type annotation is necessary because [text] is shadowed *)
+    let text_for (ui : unprocessed_item) = ui.text in
+    split_sentences d ~text:(String.concat "" @@ List.map text_for new_suffix) in
+  match result with
+  | Error err -> Error(err)
+  | Ok(()) ->
+    d.suffix <- new_suffix;
+    Ok(sentences)
 
 
 let commit : ?file:string -> ?include_ghost:bool -> ?include_suffix:bool -> t

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -476,7 +476,7 @@ let modify_suffix : index:int -> count:int -> (string * [`Blanks | `Ghost | `Com
         [List.map erase (List.take suff_offset d.suffix)
         ; sentences
         ; List.map erase (List.drop (suff_offset + count) d.suffix)] in
-  let sentences, result =
+  let parsed_sentences, result =
     (* the type annotation is necessary because [text] is shadowed *)
     let text_for (text, kind) =
       match kind with
@@ -509,14 +509,15 @@ let modify_suffix : index:int -> count:int -> (string * [`Blanks | `Ghost | `Com
       match_items ({text=ui_text;kind=ui_kind} :: acc) offset ss uis
     | _ , _ -> assert false
   in
+  let relevant_sentences = List.take (List.length sentences) @@ List.drop suff_offset parsed_sentences in
   match result with
-  | Error((a,b)) -> sentences , Error(a, b)
+  | Error((a,b)) -> relevant_sentences ,  Error(a, b)
   | Ok(()) ->
-    match match_items [] 0 new_suffix sentences with
+    match match_items [] 0 new_suffix parsed_sentences with
     | Ok(updated) ->
       d.suffix <- updated;
-      sentences , Ok(())
-    | Error((a,b)) -> sentences, Error(a,b)
+      relevant_sentences , Ok(())
+    | Error((a,b)) -> relevant_sentences, Error(a,b)
 
 
 let commit : ?file:string -> ?include_ghost:bool -> ?include_suffix:bool -> t

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -456,8 +456,8 @@ let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in
   whitespace_required d.rev_prefix
 
-let modify_suffix : index:int -> count:int -> unprocessed_item list -> t ->
-  (sentence list, string * (sentence list * string)) result
+let modify_suffix : index:int -> count:int -> (string * [`Blanks | `Ghost | `Command ]) list -> t ->
+  sentence list * (unit, string * string) result
   = fun ~index ~count sentences d ->
   let _ = get_backend d in
   let len_prefix = cursor_index d in
@@ -465,17 +465,58 @@ let modify_suffix : index:int -> count:int -> unprocessed_item list -> t ->
   let len_suffix = List.length d.suffix in
   if len_prefix + len_suffix < index + count then raise (Invalid_argument "range extends beyond end of suffix");
   let suff_offset = index - len_prefix in
-  let new_suffix: unprocessed_item list =
-      List.concat [List.take suff_offset d.suffix; sentences; List.drop (suff_offset + count) d.suffix] in
+  let new_suffix: (string * [`Blanks | `Ghost | `Command]) list =
+    let erase (ui : unprocessed_item) : string * [`Blanks | `Ghost | `Command] =
+      ui.text, match ui.kind with
+               | `Blanks -> `Blanks
+               | `Command _ -> `Command
+               | `Ghost _ -> `Ghost
+    in
+      List.concat
+        [List.map erase (List.take suff_offset d.suffix)
+        ; sentences
+        ; List.map erase (List.drop (suff_offset + count) d.suffix)] in
   let sentences, result =
     (* the type annotation is necessary because [text] is shadowed *)
-    let text_for (ui : unprocessed_item) = ui.text in
-    split_sentences d ~text:(String.concat "" @@ List.map text_for new_suffix) in
+    let text_for (text, kind) =
+      match kind with
+      | `Ghost -> " " ^ text ^ " "
+      | _ -> text
+    in
+    split_sentences d ~text:(String.concat "" @@ List.map text_for new_suffix)
+  in
+  let rec match_items (acc : unprocessed_item list) (offset : int)
+   (input : (string * [`Blanks | `Ghost | `Command]) list) (processed : sentence list) : (unprocessed_item list, string * string) result =
+   match input , processed with
+    | [], [] -> Ok(List.rev acc)
+    | [], _ :: _ -> assert false (* we can not have less input than processed items *)
+    | _ :: _ , [] -> (* if we have fewer procesed items, then we must have an error *)
+      assert false
+    | ((text, `Blanks) :: ss) , {text=ui_text; kind=`Blanks} :: uis ->
+      if text = ui_text then match_items ({text=ui_text;kind=`Blanks} :: acc) offset ss uis
+      else if String.starts_with ~prefix:text ui_text then
+              let len_text = String.length text in
+              let rtext = String.sub ui_text len_text (String.length ui_text - len_text) in
+              match_items ({text;kind=`Blanks} :: acc) offset ss ({text=rtext;kind=`Blanks} :: uis)
+      else assert false
+    | (text, `Ghost) :: ss , {text=" "; kind=`Blanks} :: {text=ui_text;kind=`Command _ as kind} :: {text=post_blanks; kind=`Blanks} :: uis ->
+      assert (ui_text = text) ;
+      assert (String.starts_with ~prefix:" " post_blanks) ;
+      if ui_text = " " then match_items ({text;kind} :: acc) (offset + 2) ss uis
+      else match_items ({text=ui_text;kind} :: acc) (offset+2) ss ({text=String.sub ui_text 1 (String.length ui_text - 1);kind=`Blanks} :: uis)
+    | (text, `Command) :: ss , {text=ui_text;kind=`Command _ as ui_kind} :: uis ->
+      assert (text = ui_text) ;
+      match_items ({text=ui_text;kind=ui_kind} :: acc) offset ss uis
+    | _ , _ -> assert false
+  in
   match result with
-  | Error((a,b)) -> Error(a, (sentences, b))
+  | Error((a,b)) -> sentences , Error(a, b)
   | Ok(()) ->
-    d.suffix <- new_suffix;
-    Ok(sentences)
+    match match_items [] 0 new_suffix sentences with
+    | Ok(updated) ->
+      d.suffix <- updated;
+      sentences , Ok(())
+    | Error((a,b)) -> sentences, Error(a,b)
 
 
 let commit : ?file:string -> ?include_ghost:bool -> ?include_suffix:bool -> t

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -456,6 +456,19 @@ let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in
   whitespace_required d.rev_prefix
 
+let modify_suffix : index:int -> count:int -> unprocessed_item list -> t -> unit = fun ~index ~count sentences d ->
+  let _ = get_backend d in
+  let len_prefix = cursor_index d in
+  if index < len_prefix then raise (Invalid_argument "index occurs in prefix");
+  let len_suffix = List.length d.suffix in
+  if len_prefix + len_suffix < index + count then raise (Invalid_argument "range extends beyond end of suffix");
+  let suff_offset = index - len_prefix in
+  let new_suffix =
+    List.concat [List.take suff_offset d.suffix; sentences; List.drop (suff_offset + count) d.suffix] in
+  assert false
+
+
+
 let commit : ?file:string -> ?include_ghost:bool -> ?include_suffix:bool -> t
     -> (unit, string) result =
     fun ?file ?(include_ghost=false) ?(include_suffix=true) d ->

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -194,7 +194,7 @@ val clear_suffix : ?count:int -> t -> unit
     - the inserted sentences are not "synterp-compatible" with the rest of
       the suffix. *)
 val modify_suffix : index:int -> count:int -> unprocessed_item list -> t ->
-  (sentence list, string * string) result
+  (sentence list, string * (sentence list * string)) result
 
 (** [run_step d] advances the cursor of document [d] over the next unprocessed
     item of the document suffix, returning similar data to [insert_command] if

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -193,7 +193,8 @@ val clear_suffix : ?count:int -> t -> unit
     - there are not [count] items after [index]
     - the inserted sentences are not "synterp-compatible" with the rest of
       the suffix. *)
-val modify_suffix : index:int -> ?count:int -> unprocessed_item list -> t -> unit
+val modify_suffix : index:int -> count:int -> unprocessed_item list -> t ->
+  (sentence list, string * string) result
 
 (** [run_step d] advances the cursor of document [d] over the next unprocessed
     item of the document suffix, returning similar data to [insert_command] if

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -84,6 +84,29 @@ val load_file : t -> (unit, string * Loc.t option) result
 (** Partial AST data attached to a Rocq vernacular command. *)
 type vernac_data = Rocq_vernac_entry.command
 
+(** Document item kind: blank characters, command, or ghost command. *)
+type item_kind = [`Blanks | `Command of vernac_data | `Ghost of vernac_data]
+
+(** Representation of a processed item (in the document's prefix). *)
+type processed_item = {
+  index : int;
+  (** Index in the document, as passed to, e.g., [advance_to]. *)
+  kind : item_kind;
+  (** Item kind. *)
+  off : int;
+  (** Byte offset of the item in the document. *)
+  text : string;
+  (** Text of the item. *)
+}
+
+(** Representation of an unprocessed item (in the document's suffix). *)
+type unprocessed_item = {
+  kind : item_kind;
+  (** Item kind. *)
+  text : string;
+  (** Text of the item. *)
+}
+
 (** Rocq sentence, as returned by the sentence-splitter. *)
 type sentence = {
   kind : [`Blanks | `Command of vernac_data];
@@ -160,6 +183,18 @@ val with_rollback : t -> (unit -> 'a) -> 'a
     [Invalid_argument] is raised. *)
 val clear_suffix : ?count:int -> t -> unit
 
+(** [modify_suffix index count sentences] replaces [count] sentences starting
+    at [index] with the new [sentences]. The inserted sentences are checked
+    to make sure that they pass synterp given the current document.
+
+    An [Invalid_argument] is raised if:
+    - [index] does not exist or is part of the prefix
+    - [count] is negative
+    - there are not [count] items after [index]
+    - the inserted sentences are not "synterp-compatible" with the rest of
+      the suffix. *)
+val modify_suffix : index:int -> ?count:int -> unprocessed_item list -> t -> unit
+
 (** [run_step d] advances the cursor of document [d] over the next unprocessed
     item of the document suffix, returning similar data to [insert_command] if
     the item is a command. Exception [Invalid_argument] is raised when [d] has
@@ -196,29 +231,6 @@ val advance_to : t -> index:int
     [Invalid_argument] is raised. Valid indices range from [0] to one past the
     index of the last item in the document's suffix. *)
 val go_to : t -> index:int -> (unit, string * command_error option) result
-
-(** Document item kind: blank characters, command, or ghost command. *)
-type item_kind = [`Blanks | `Command of vernac_data | `Ghost of vernac_data]
-
-(** Representation of a processed item (in the document's prefix). *)
-type processed_item = {
-  index : int;
-  (** Index in the document, as passed to, e.g., [advance_to]. *)
-  kind : item_kind;
-  (** Item kind. *)
-  off : int;
-  (** Byte offset of the item in the document. *)
-  text : string;
-  (** Text of the item. *)
-}
-
-(** Representation of an unprocessed item (in the document's suffix). *)
-type unprocessed_item = {
-  kind : item_kind;
-  (** Item kind. *)
-  text : string;
-  (** Text of the item. *)
-}
 
 (** [rev_prefix d] returns the reversed list of already-processed items in the
     document [d] (in other words, its prefix). *)

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -193,8 +193,9 @@ val clear_suffix : ?count:int -> t -> unit
     - there are not [count] items after [index]
     - the inserted sentences are not "synterp-compatible" with the rest of
       the suffix. *)
-val modify_suffix : index:int -> count:int -> unprocessed_item list -> t ->
-  (sentence list, string * (sentence list * string)) result
+val modify_suffix : index:int -> count:int ->
+  (string * [`Blanks | `Ghost | `Command ]) list -> t ->
+  sentence list * (unit, string * string) result
 
 (** [run_step d] advances the cursor of document [d] over the next unprocessed
     item of the document suffix, returning similar data to [insert_command] if

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/protocol.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/protocol.py
@@ -12,6 +12,14 @@ from .file_offset import FileOffset
 logger = logging.getLogger(__name__)
 
 
+class SentenceBase(Protocol):
+    """A base class for Sentence-like things.
+    This should include `PrefixItem`, `SuffixItem`, and `Sentence`."""
+
+    text: str
+    kind: Literal["blanks", "command", "ghost"]
+
+
 class RocqCursorProtocolAsync(Protocol):
     async def advance_to(
         self, index: int
@@ -86,7 +94,7 @@ class RocqCursorProtocolAsync(Protocol):
     ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]: ...
 
     async def insert_sentence(
-        self, sentence: rdm_api.Sentence
+        self, sentence: SentenceBase
     ) -> rdm_api.CommandData | None | rdm_api.Err[rdm_api.CommandError]:
         if sentence.kind == "blanks":
             await self.insert_blanks(sentence.text)
@@ -96,11 +104,11 @@ class RocqCursorProtocolAsync(Protocol):
                 sentence.text, ghost=sentence.kind == "ghost"
             )
 
-    async def insert_sentences(
-        self, sentences: list[rdm_api.Sentence], *, allow_partial: bool = False
+    async def insert_sentences[T: SentenceBase](
+        self, sentences: Sequence[T], *, allow_partial: bool = False
     ) -> tuple[
         list[rdm_api.CommandData],
-        None | tuple[rdm_api.Err[rdm_api.CommandError], list[rdm_api.Sentence]],
+        None | tuple[rdm_api.Err[rdm_api.CommandError], Sequence[T]],
     ]:
         """The return value contains the results from successfully evaluated
         commands as well as any error.
@@ -121,6 +129,29 @@ class RocqCursorProtocolAsync(Protocol):
             elif isinstance(result, rdm_api.CommandData):
                 data.append(result)
         return (data, None)
+
+    async def copy_from(
+        self,
+        src: RocqCursor,
+        *,
+        prefix_only: Literal[True] = True,
+        extension: Literal[True] = True,
+    ) -> None:
+        """Copy the contents from `src` to `self`"""
+        start_prefix = await self.doc_prefix()
+        end_prefix = await src.doc_prefix()
+        assert end_prefix[0 : len(start_prefix)] == start_prefix
+        await self.insert_sentences(end_prefix[len(start_prefix) :])
+        for i in end_prefix[len(start_prefix) :]:
+            if i.kind == "blanks":
+                await self.insert_blanks(i.text)
+            else:
+                assert isinstance(
+                    await self.insert_command(
+                        i.text, ghost=i.kind == "ghost", blanks=None
+                    ),
+                    rdm_api.CommandData,
+                )
 
     # TODO: we should really reduce the repetition on [query],
     # there are 5 functions, but they all do basically the same thing
@@ -157,7 +188,7 @@ class RocqCursorProtocolAsync(Protocol):
     ) -> None | rdm_api.Err[rdm_api.StepsError]:
         for cnt in range(count):
             r = await self.run_step()
-            if isinstance(r, rdm_api.Err):
+            if isinstance(r, rdm_api.Err[rdm_api.CommandError]):
                 return rdm_api.Err(
                     message=r.message,
                     data=rdm_api.StepsError(cmd_error=r.data, nb_processed=cnt),

--- a/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
@@ -517,6 +517,23 @@ class RocqDocManagerAPI:
             return Err(result.message, data)
         return None
 
+    def modify_suffix(
+        self,
+        cursor: int,
+        index: int,
+        count: int,
+        items: list[SuffixItem],
+    ) -> list[Sentence] | Err[SentenceSplitError]:
+        """Modify the suffix of the document."""
+        result = self._rpc.raw_request(
+            "modify_suffix",
+            [cursor, index, count, items],
+        )
+        if isinstance(result, Err):
+            data = SentenceSplitError.model_validate(result.data)
+            return Err(result.message, data)
+        return [Sentence.model_validate(v1) for v1 in result.result]
+
     def query(
         self,
         cursor: int,
@@ -902,6 +919,23 @@ class RocqDocManagerAPIAsync:
             data = None
             return Err(result.message, data)
         return None
+
+    async def modify_suffix(
+        self,
+        cursor: int,
+        index: int,
+        count: int,
+        items: list[SuffixItem],
+    ) -> list[Sentence] | Err[SentenceSplitError]:
+        """Modify the suffix of the document."""
+        result = await self._rpc.raw_request(
+            "modify_suffix",
+            [cursor, index, count, items],
+        )
+        if isinstance(result, Err):
+            data = SentenceSplitError.model_validate(result.data)
+            return Err(result.message, data)
+        return [Sentence.model_validate(v1) for v1 in result.result]
 
     async def query(
         self,

--- a/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
@@ -12,6 +12,7 @@ __all__ = [
     "Error",
     "Resp",
     "SuffixItem",
+    "UnprocessedItem",
     "PrefixItem",
     "StepsError",
     "CommandError",
@@ -260,6 +261,17 @@ class PrefixItem(BaseModel):
         kw_only=True,
     )
     offset: int = Field(
+        kw_only=True,
+    )
+    kind: Literal["blanks", "command", "ghost"] = Field(
+        kw_only=True,
+    )
+
+
+class UnprocessedItem(BaseModel):
+    """An unprocessed item, to be inserted."""
+
+    text: str = Field(
         kw_only=True,
     )
     kind: Literal["blanks", "command", "ghost"] = Field(
@@ -522,7 +534,7 @@ class RocqDocManagerAPI:
         cursor: int,
         index: int,
         count: int,
-        items: list[SuffixItem],
+        items: list[UnprocessedItem],
     ) -> list[Sentence] | Err[SentenceSplitError]:
         """Modify the suffix of the document."""
         result = self._rpc.raw_request(
@@ -925,7 +937,7 @@ class RocqDocManagerAPIAsync:
         cursor: int,
         index: int,
         count: int,
-        items: list[SuffixItem],
+        items: list[UnprocessedItem],
     ) -> list[Sentence] | Err[SentenceSplitError]:
         """Modify the suffix of the document."""
         result = await self._rpc.raw_request(

--- a/rocq-ltac-interp/src/rocq_ltac_interp/tacinterp.py
+++ b/rocq-ltac-interp/src/rocq_ltac_interp/tacinterp.py
@@ -106,6 +106,9 @@ type TacticAST = list[str | TacticAST]
 
 
 async def copy_extension(*, src: RocqCursor, dst: RocqCursor) -> None:
+    """Copy the prefix of `src` to `dst`.
+    The prefix of `src` is expected to be a prefix of `dst`.
+    """
     # copy the contents from self._cloned to self._cursor
     start_prefix = await dst.doc_prefix()
     end_prefix = await src.doc_prefix()
@@ -149,7 +152,7 @@ class LtacTry(AbstractAsyncContextManager):
         assert self._cloned is not None
         if exc_type is None:
             # copy the contents from self._cloned to self._cursor
-            await copy_extension(src=self._cloned, dst=self._cursor)
+            await self._cursor.copy_from(src=self._cloned, prefix_only=True)
         await self._cloned.dispose()
         self._cloned = None
         return False


### PR DESCRIPTION
This exposes a new primitive that allows for modifying a suffix without processing it.

The implementation seeks to maintain the invariant that the suffix is always processable.