### PR TITLE
Implement [replace_suffix]

### DIFF
--- a/rocq-doc-manager/README.md
+++ b/rocq-doc-manager/README.md
@@ -347,6 +347,16 @@ API Methods
 - Error payload: a `null` value.
 - Failure mode: recoverable failure.
 
+### `replace_suffix`
+
+- Description: replaces the suffix with the sentences from the text.
+- Arguments (in order, or named):
+  - `cursor`: the cursor to perform the operation on (as an integer).
+  - `text`: text to split into sentences (as a string).
+- Response payload: a list where each element is an instance of the `Sentence` object.
+- Error payload: an instance of the `SentenceSplitError` object.
+- Failure mode: recoverable failure.
+
 ### `revert_before`
 
 - Description: revert the cursor to an earlier point in the document.

--- a/rocq-doc-manager/README.md
+++ b/rocq-doc-manager/README.md
@@ -353,6 +353,7 @@ API Methods
 - Arguments (in order, or named):
   - `cursor`: the cursor to perform the operation on (as an integer).
   - `text`: text to split into sentences (as a string).
+  - `count`: the number of items to replace (as either `null` or an integer).
 - Response payload: a list where each element is an instance of the `Sentence` object.
 - Error payload: an instance of the `SentenceSplitError` object.
 - Failure mode: recoverable failure.

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -355,11 +355,10 @@ let _ =
       sentences from the text" ~args
     ~ret:S.(list (obj sentence)) ~err:S.(obj sentence_split_error)
     @@ fun d (text, (count, ())) ->
-  let (sentences, ret) = Document.replace_suffix d ~count ~text in
+  let (sentences, ret) = Document.replace_suffix d ?count ~text in
   match ret with
   | Ok(())         -> Ok(sentences)
   | Error(s, rest) -> Error(s, (sentences, (rest, ())))
-
 
 let _ =
   let args =

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -347,6 +347,21 @@ let _ =
 
 let _ =
   let args =
+    A.add ~name:"text" ~descr:"text to split into sentences" S.string @@
+    A.nil
+  in
+  declare_full ~name:"replace_suffix" ~descr:"replaces the suffix with the \
+      sentences from the text" ~args
+    ~ret:S.(list (obj sentence)) ~err:S.(obj sentence_split_error)
+    @@ fun d (text, ()) ->
+  let (sentences, ret) = Document.replace_suffix d ~text in
+  match ret with
+  | Ok(())         -> Ok(sentences)
+  | Error(s, rest) -> Error(s, (sentences, (rest, ())))
+
+
+let _ =
+  let args =
     A.add ~name:"text" ~descr:"text of the blanks to insert" S.string @@
     A.nil
   in

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -348,13 +348,14 @@ let _ =
 let _ =
   let args =
     A.add ~name:"text" ~descr:"text to split into sentences" S.string @@
+    A.add ~name:"count" ~descr:"the number of items to replace" (S.nullable S.int) @@
     A.nil
   in
   declare_full ~name:"replace_suffix" ~descr:"replaces the suffix with the \
       sentences from the text" ~args
     ~ret:S.(list (obj sentence)) ~err:S.(obj sentence_split_error)
-    @@ fun d (text, ()) ->
-  let (sentences, ret) = Document.replace_suffix d ~text in
+    @@ fun d (text, (count, ())) ->
+  let (sentences, ret) = Document.replace_suffix d ~count ~text in
   match ret with
   | Ok(())         -> Ok(sentences)
   | Error(s, rest) -> Error(s, (sentences, (rest, ())))

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -456,38 +456,42 @@ let split_sentences : t -> text:string ->
   in
   (sentences, res)
 
-let replace_suffix : t -> count:int option -> text:string ->
-    sentence list * (unit, string * string) result = fun d ~count ~text ->
+let replace_suffix : ?count:int -> t -> text:string ->
+    sentence list * (unit, string * string) result = fun ?count d ~text ->
+  let _ = get_backend d in
+  let check_count count =
+    if count < 0 then invalid_arg "negative count";
+    if List.length d.suffix < count then invalid_arg "invalid count"
+  in
+  Option.iter check_count count;
   let (sentences, res) as result = split_sentences d ~text in
-  if Result.is_ok res then
-    match count with
-    | Some drop ->
-      let rec ws_required acc : unprocessed_item list -> _ = function
-        | [] -> acc
-        | ({kind;text} :: rest) ->
-          match kind with
-          | `Blanks -> ws_required false rest
-          | `Command(_) -> ws_required (String.ends_with ~suffix:"." text) rest
-          | `Ghost (_) -> ws_required acc rest
+  if Result.is_error res then result else
+  let new_items = List.map sentence_to_unprocessed_item sentences in
+  let new_suffix =
+    match count with None -> new_items | Some(count) ->
+    let kept = List.drop count d.suffix in
+    let ws_required =
+      let rec whitespace_required_after (sentences : sentence list) =
+        match sentences with
+        | [] -> whitespace_required d.rev_prefix
+        | [{kind = `Blanks; _}] -> false
+        | [{kind = `Command(_); text}] -> String.ends_with ~suffix:"." text
+        | _ :: sentences -> whitespace_required_after sentences
       in
-      let rec ws_satisfied : unprocessed_item list -> bool = function
-        | [] -> true
-        | {kind=`Blanks;text=_} :: _ -> true
-        | {kind=`Ghost(_);text=_} :: rest -> ws_satisfied rest
-        | {kind=`Command(_);text=_} :: _ -> false
-      in
-      let new_items = List.map sentence_to_unprocessed_item sentences in
-      let ws_required = ws_required false new_items in
-      let kept = List.drop drop d.suffix in
-      if ws_required && not (ws_satisfied kept) then
-        sentences, Error("Missing whitespace after last sentence", "oops")
-      else
-        let _ = d.suffix <- (new_items @ kept) in
-        result
-    | None ->
-      d.suffix <- List.map sentence_to_unprocessed_item sentences ;
-      result
-  else result
+      whitespace_required_after sentences
+    in
+    let rec has_leading_whitespace (items : unprocessed_item list) =
+      match items with
+      | [] -> true
+      | {kind = `Blanks; _} :: _ -> true
+      | {kind = `Command(_); _} :: _ -> false
+      | _ :: items -> has_leading_whitespace items
+    in
+    if ws_required && not (has_leading_whitespace kept) then
+      invalid_arg "blanks required at the end of the inserted text";
+    new_items @ kept
+  in
+  d.suffix <- new_suffix; result
 
 let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -452,6 +452,20 @@ let split_sentences : t -> text:string ->
   in
   (sentences, res)
 
+let replace_suffix : t -> text:string -> sentence list * (unit, string * string) result = fun d ~text ->
+  let sentences, result = split_sentences d ~text in
+  let _ =
+    let to_unprocessed ({kind;text} : sentence) : unprocessed_item =
+      { text;
+        kind= match kind with
+              | `Blanks -> `Blanks
+              | `Command(vd) -> `Command(vd) }
+    in
+    if result = Ok(())
+    then d.suffix <- List.map to_unprocessed sentences
+  in
+  sentences , result
+
 let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in
   whitespace_required d.rev_prefix

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -399,6 +399,10 @@ type sentence = {
   text : string;
 }
 
+let sentence_to_unprocessed_item : sentence -> unprocessed_item = fun s ->
+  let k = match s.kind with `Blanks -> `Blanks | `Command(d) -> `Command(d) in
+  {text = s.text; kind = k}
+
 let split_sentences : t -> text:string ->
     sentence list * (unit, string * string) result = fun d ~text ->
   let {file; args; _} = get_backend d in
@@ -452,19 +456,12 @@ let split_sentences : t -> text:string ->
   in
   (sentences, res)
 
-let replace_suffix : t -> text:string -> sentence list * (unit, string * string) result = fun d ~text ->
-  let sentences, result = split_sentences d ~text in
-  let _ =
-    let to_unprocessed ({kind;text} : sentence) : unprocessed_item =
-      { text;
-        kind= match kind with
-              | `Blanks -> `Blanks
-              | `Command(vd) -> `Command(vd) }
-    in
-    if result = Ok(())
-    then d.suffix <- List.map to_unprocessed sentences
-  in
-  sentences , result
+let replace_suffix : t -> text:string ->
+    sentence list * (unit, string * string) result = fun d ~text ->
+  let (sentences, res) as result = split_sentences d ~text in
+  if Result.is_ok res then
+    d.suffix <- List.map sentence_to_unprocessed_item sentences;
+  result
 
 let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -456,12 +456,38 @@ let split_sentences : t -> text:string ->
   in
   (sentences, res)
 
-let replace_suffix : t -> text:string ->
-    sentence list * (unit, string * string) result = fun d ~text ->
+let replace_suffix : t -> count:int option -> text:string ->
+    sentence list * (unit, string * string) result = fun d ~count ~text ->
   let (sentences, res) as result = split_sentences d ~text in
   if Result.is_ok res then
-    d.suffix <- List.map sentence_to_unprocessed_item sentences;
-  result
+    match count with
+    | Some drop ->
+      let rec ws_required acc : unprocessed_item list -> _ = function
+        | [] -> acc
+        | ({kind;text} :: rest) ->
+          match kind with
+          | `Blanks -> ws_required false rest
+          | `Command(_) -> ws_required (String.ends_with ~suffix:"." text) rest
+          | `Ghost (_) -> ws_required acc rest
+      in
+      let rec ws_satisfied : unprocessed_item list -> bool = function
+        | [] -> true
+        | {kind=`Blanks;text=_} :: _ -> true
+        | {kind=`Ghost(_);text=_} :: rest -> ws_satisfied rest
+        | {kind=`Command(_);text=_} :: _ -> false
+      in
+      let new_items = List.map sentence_to_unprocessed_item sentences in
+      let ws_required = ws_required false new_items in
+      let kept = List.drop drop d.suffix in
+      if ws_required && not (ws_satisfied kept) then
+        sentences, Error("Missing whitespace after last sentence", "oops")
+      else
+        let _ = d.suffix <- (new_items @ kept) in
+        result
+    | None ->
+      d.suffix <- List.map sentence_to_unprocessed_item sentences ;
+      result
+  else result
 
 let whitespace_required : t -> bool = fun d ->
   let _ = get_backend d in

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -109,7 +109,7 @@ val split_sentences : t -> text:string
 (** [replace_suffix d ~text] is similar to [split_sentences d ~text], with the
     addition of replacing the document suffix with the obtained sentences upon
     success. If sentence-splitting fails, the suffix is left unchanged. *)
-val replace_suffix : t -> text:string
+val replace_suffix : t -> count:int option -> text:string
   -> sentence list * (unit, string * string) result
 
 (** Data returned by the top-level when running a command. *)

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -106,6 +106,9 @@ val whitespace_required : t -> bool
 val split_sentences : t -> text:string
   -> sentence list * (unit, string * string) result
 
+val replace_suffix : t -> text:string
+  -> sentence list * (unit, string * string) result
+
 (** Data returned by the top-level when running a command. *)
 type command_data = Rocq_toplevel.run_data
 

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -106,6 +106,9 @@ val whitespace_required : t -> bool
 val split_sentences : t -> text:string
   -> sentence list * (unit, string * string) result
 
+(** [replace_suffix d ~text] is similar to [split_sentences d ~text], with the
+    addition of replacing the document suffix with the obtained sentences upon
+    success. If sentence-splitting fails, the suffix is left unchanged. *)
 val replace_suffix : t -> text:string
   -> sentence list * (unit, string * string) result
 

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -106,10 +106,14 @@ val whitespace_required : t -> bool
 val split_sentences : t -> text:string
   -> sentence list * (unit, string * string) result
 
-(** [replace_suffix d ~text] is similar to [split_sentences d ~text], with the
-    addition of replacing the document suffix with the obtained sentences upon
-    success. If sentence-splitting fails, the suffix is left unchanged. *)
-val replace_suffix : t -> count:int option -> text:string
+(** [replace_suffix d ?count ~text] is like [split_sentences d ~text], but the
+    obtained sentences are used to replace the suffix in case of success. When
+    [count] is not [None], only the given number of suffix items are replaced,
+    instead of the whole suffix. The [Invalid_argument] exception is raised if
+    [text] does not appropriately start and end with blanks, or if [count] has
+    an invalid value. In case of exception or error, the state of the document
+    is left unchanged. *)
+val replace_suffix : ?count:int -> t -> text:string
   -> sentence list * (unit, string * string) result
 
 (** Data returned by the top-level when running a command. *)

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delegate.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delegate.py
@@ -105,6 +105,12 @@ class DelegateRocqCursor(RocqCursor):
         return await self._cursor.clear_suffix(count)
 
     @override
+    async def replace_suffix(
+        self, text: str
+    ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]:
+        return await self._cursor.replace_suffix(text)
+
+    @override
     async def commit(
         self,
         file: str | None,

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delegate.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delegate.py
@@ -106,9 +106,9 @@ class DelegateRocqCursor(RocqCursor):
 
     @override
     async def replace_suffix(
-        self, text: str
+        self, text: str, *, count: int | None = None
     ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]:
-        return await self._cursor.replace_suffix(text)
+        return await self._cursor.replace_suffix(text, count=count)
 
     @override
     async def commit(

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delimited.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delimited.py
@@ -111,11 +111,16 @@ class DelimitedRocqCursor(DelegateRocqCursor):
 
     @override
     async def replace_suffix(
-        self, text: str
+        self, text: str, *, count: int | None = None
     ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]:
-        raise NotImplementedError(
-            "replace_suffix is not supported for delimited cursors"
-        )
+        suffix = await self.doc_suffix()
+        len_suffix = len(suffix)
+        nb_to_clear = len_suffix if count is None else count
+        if len_suffix < nb_to_clear:
+            raise Exception(
+                f"Cannot clear {nb_to_clear} suffix items (limited to {len_suffix})"
+            )
+        return await self._cursor.replace_suffix(text, count=nb_to_clear)
 
     @override
     async def clone(self, *, materialize: bool = False) -> RocqCursor:

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delimited.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/delimited.py
@@ -110,6 +110,14 @@ class DelimitedRocqCursor(DelegateRocqCursor):
         await self._cursor.clear_suffix(nb_to_clear)
 
     @override
+    async def replace_suffix(
+        self, text: str
+    ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]:
+        raise NotImplementedError(
+            "replace_suffix is not supported for delimited cursors"
+        )
+
+    @override
     async def clone(self, *, materialize: bool = False) -> RocqCursor:
         cursor = await self._cursor.clone(materialize=materialize)
         return DelimitedRocqCursor(

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/doc_cursor.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/doc_cursor.py
@@ -55,6 +55,12 @@ class RDMRocqCursor(RocqCursor):
         return await self._rdm.clear_suffix(self._cursor, count)
 
     @override
+    async def replace_suffix(
+        self, text: str
+    ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]:
+        return await self._rdm.replace_suffix(self._cursor, text)
+
+    @override
     async def materialize(self) -> None:
         """Enable parallel processing on this cursor."""
         result = await self._rdm.materialize(self._cursor)

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/doc_cursor.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/doc_cursor.py
@@ -56,9 +56,9 @@ class RDMRocqCursor(RocqCursor):
 
     @override
     async def replace_suffix(
-        self, text: str
+        self, text: str, *, count: int | None = None
     ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]:
-        return await self._rdm.replace_suffix(self._cursor, text)
+        return await self._rdm.replace_suffix(self._cursor, text, count=count)
 
     @override
     async def materialize(self) -> None:

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/protocol.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/protocol.py
@@ -19,6 +19,10 @@ class RocqCursorProtocolAsync(Protocol):
 
     async def clear_suffix(self, count: int | None = None) -> None: ...
 
+    async def replace_suffix(
+        self, text: str
+    ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]: ...
+
     async def materialize(self) -> None:
         """Enable parallel processing on this cursor."""
         ...

--- a/rocq-doc-manager/python/src/rocq_doc_manager/cursor/protocol.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/cursor/protocol.py
@@ -20,7 +20,7 @@ class RocqCursorProtocolAsync(Protocol):
     async def clear_suffix(self, count: int | None = None) -> None: ...
 
     async def replace_suffix(
-        self, text: str
+        self, text: str, *, count: int | None = None
     ) -> list[rdm_api.Sentence] | rdm_api.Err[rdm_api.SentenceSplitError]: ...
 
     async def materialize(self) -> None:

--- a/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
@@ -596,6 +596,21 @@ class RocqDocManagerAPI:
             return Err(result.message, data)
         return [str(v1) for v1 in result.result]
 
+    def replace_suffix(
+        self,
+        cursor: int,
+        text: str,
+    ) -> list[Sentence] | Err[SentenceSplitError]:
+        """Replaces the suffix with the sentences from the text."""
+        result = self._rpc.raw_request(
+            "replace_suffix",
+            [cursor, text],
+        )
+        if isinstance(result, Err):
+            data = SentenceSplitError.model_validate(result.data)
+            return Err(result.message, data)
+        return [Sentence.model_validate(v1) for v1 in result.result]
+
     def revert_before(
         self,
         cursor: int,
@@ -981,6 +996,21 @@ class RocqDocManagerAPIAsync:
             data = None
             return Err(result.message, data)
         return [str(v1) for v1 in result.result]
+
+    async def replace_suffix(
+        self,
+        cursor: int,
+        text: str,
+    ) -> list[Sentence] | Err[SentenceSplitError]:
+        """Replaces the suffix with the sentences from the text."""
+        result = await self._rpc.raw_request(
+            "replace_suffix",
+            [cursor, text],
+        )
+        if isinstance(result, Err):
+            data = SentenceSplitError.model_validate(result.data)
+            return Err(result.message, data)
+        return [Sentence.model_validate(v1) for v1 in result.result]
 
     async def revert_before(
         self,

--- a/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
@@ -600,11 +600,12 @@ class RocqDocManagerAPI:
         self,
         cursor: int,
         text: str,
+        count: int | None,
     ) -> list[Sentence] | Err[SentenceSplitError]:
         """Replaces the suffix with the sentences from the text."""
         result = self._rpc.raw_request(
             "replace_suffix",
-            [cursor, text],
+            [cursor, text, count],
         )
         if isinstance(result, Err):
             data = SentenceSplitError.model_validate(result.data)
@@ -1001,11 +1002,12 @@ class RocqDocManagerAPIAsync:
         self,
         cursor: int,
         text: str,
+        count: int | None,
     ) -> list[Sentence] | Err[SentenceSplitError]:
         """Replaces the suffix with the sentences from the text."""
         result = await self._rpc.raw_request(
             "replace_suffix",
-            [cursor, text],
+            [cursor, text, count],
         )
         if isinstance(result, Err):
             data = SentenceSplitError.model_validate(result.data)

--- a/rocq-doc-manager/tests/replace_suffix.t
+++ b/rocq-doc-manager/tests/replace_suffix.t
@@ -9,20 +9,20 @@
 
   $ cat > calls.txt <<EOF
   > cursor_index [0]
-  > replace_suffix [0,"Definition test4 := 0."]
+  > replace_suffix [0,"Definition test4 := 0.",null]
   > cursor_index [0]
   > doc_suffix [0]
   > run_step [0]
-  > replace_suffix [0,"\nDefinition my_test := test4 + 1.\n"]
+  > replace_suffix [0,"\nDefinition my_test := test4 + 1.\n",null]
   > doc_suffix [0]
   > cursor_index [0]
   > run_step [0]
   > run_step [0]
   > go_to [0,0]
   > doc_suffix [0]
-  > replace_suffix [0,"Definition foo := 0."]
+  > replace_suffix [0,"Definition foo := 0.",null]
   > run_step [0]
-  > replace_suffix [0,"Definition baz := 0."]
+  > replace_suffix [0,"Definition baz := 0.",null]
   > doc_suffix [0]
   > EOF
 

--- a/rocq-doc-manager/tests/replace_suffix.t
+++ b/rocq-doc-manager/tests/replace_suffix.t
@@ -1,0 +1,192 @@
+  $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
+  $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
+  $ export DUNE_CACHE=disabled
+  $ cat > test.v <<EOF
+  > Definition test1 := nat.
+  > Definition test2 := nat.
+  > Definition test3 := nat.
+  > EOF
+
+  $ cat > calls.txt <<EOF
+  > cursor_index [0]
+  > replace_suffix [0,"Definition test4 := 0."]
+  > cursor_index [0]
+  > doc_suffix [0]
+  > run_step [0]
+  > replace_suffix [0,"\nDefinition my_test := test4 + 1.\n"]
+  > doc_suffix [0]
+  > cursor_index [0]
+  > run_step [0]
+  > run_step [0]
+  > go_to [0,0]
+  > doc_suffix [0]
+  > replace_suffix [0,"Definition foo := 0."]
+  > run_step [0]
+  > replace_suffix [0,"Definition baz := 0."]
+  > doc_suffix [0]
+  > EOF
+
+  $ cat calls.txt | jsonrpc-tp.build_requests | jsonrpc-tp.tp_wrap > commands.txt
+
+  $ cat commands.txt | rocq-doc-manager test.v -- -Q . test.dir | jsonrpc-tp.tp_unwrap
+  { "method": "ready_seq", "jsonrpc": "2.0" }
+  { "id": 1, "jsonrpc": "2.0", "result": 0 }
+  {
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": [
+      {
+        "kind": "command",
+        "text": "Definition test4 := 0.",
+        "data": {
+          "kind": "Definition",
+          "pure": true,
+          "attrs": { "id": "test4", "kind": "Definition", "proof": false }
+        }
+      }
+    ]
+  }
+  { "id": 3, "jsonrpc": "2.0", "result": 0 }
+  {
+    "id": 4,
+    "jsonrpc": "2.0",
+    "result": [
+      {
+        "kind": "command",
+        "text": "Definition test4 := 0.",
+        "data": {
+          "kind": "Definition",
+          "pure": true,
+          "attrs": { "id": "test4", "kind": "Definition", "proof": false }
+        }
+      }
+    ]
+  }
+  {
+    "id": 5,
+    "jsonrpc": "2.0",
+    "result": {
+      "globrefs_diff": { "added_constants": [ "test.dir.test.test4" ] },
+      "feedback_messages": [ { "level": "info", "text": "test4 is defined" } ],
+      "synterp_ast": {
+        "kind": "Definition",
+        "pure": true,
+        "attrs": { "id": "test4", "kind": "Definition", "proof": false }
+      }
+    }
+  }
+  {
+    "id": 6,
+    "jsonrpc": "2.0",
+    "result": [
+      { "kind": "blanks", "text": "\n" },
+      {
+        "kind": "command",
+        "text": "Definition my_test := test4 + 1.",
+        "data": {
+          "kind": "Definition",
+          "pure": true,
+          "attrs": { "id": "my_test", "kind": "Definition", "proof": false }
+        }
+      },
+      { "kind": "blanks", "text": "\n" }
+    ]
+  }
+  {
+    "id": 7,
+    "jsonrpc": "2.0",
+    "result": [
+      { "kind": "blanks", "text": "\n" },
+      {
+        "kind": "command",
+        "text": "Definition my_test := test4 + 1.",
+        "data": {
+          "kind": "Definition",
+          "pure": true,
+          "attrs": { "id": "my_test", "kind": "Definition", "proof": false }
+        }
+      },
+      { "kind": "blanks", "text": "\n" }
+    ]
+  }
+  { "id": 8, "jsonrpc": "2.0", "result": 1 }
+  { "id": 9, "jsonrpc": "2.0", "result": null }
+  {
+    "id": 10,
+    "jsonrpc": "2.0",
+    "result": {
+      "globrefs_diff": { "added_constants": [ "test.dir.test.my_test" ] },
+      "feedback_messages": [
+        { "level": "info", "text": "my_test is defined" }
+      ],
+      "synterp_ast": {
+        "kind": "Definition",
+        "pure": true,
+        "attrs": { "id": "my_test", "kind": "Definition", "proof": false }
+      }
+    }
+  }
+  { "id": 11, "jsonrpc": "2.0", "result": null }
+  {
+    "id": 12,
+    "jsonrpc": "2.0",
+    "result": [
+      {
+        "kind": "command",
+        "text": "Definition test4 := 0.",
+        "data": {
+          "kind": "Definition",
+          "pure": true,
+          "attrs": { "id": "test4", "kind": "Definition", "proof": false }
+        }
+      },
+      { "kind": "blanks", "text": "\n" },
+      {
+        "kind": "command",
+        "text": "Definition my_test := test4 + 1.",
+        "data": {
+          "kind": "Definition",
+          "pure": true,
+          "attrs": { "id": "my_test", "kind": "Definition", "proof": false }
+        }
+      },
+      { "kind": "blanks", "text": "\n" }
+    ]
+  }
+  {
+    "id": 13,
+    "jsonrpc": "2.0",
+    "result": [
+      {
+        "kind": "command",
+        "text": "Definition foo := 0.",
+        "data": {
+          "kind": "Definition",
+          "pure": true,
+          "attrs": { "id": "foo", "kind": "Definition", "proof": false }
+        }
+      }
+    ]
+  }
+  {
+    "id": 14,
+    "jsonrpc": "2.0",
+    "result": {
+      "globrefs_diff": { "added_constants": [ "test.dir.test.foo" ] },
+      "feedback_messages": [ { "level": "info", "text": "foo is defined" } ],
+      "synterp_ast": {
+        "kind": "Definition",
+        "pure": true,
+        "attrs": { "id": "foo", "kind": "Definition", "proof": false }
+      }
+    }
+  }
+  {
+    "id": 15,
+    "jsonrpc": "2.0",
+    "error": {
+      "code": -32602,
+      "message": "Invalid parameters for method replace_suffix: leading blanks required at this point in the document."
+    }
+  }
+  { "id": 16, "jsonrpc": "2.0", "result": [] }


### PR DESCRIPTION
This gets around the sentence-level complexity of `modify_suffix` by using a string as the text to insert.