### PR TITLE
rocq-ed: New CLI editor for Rocq.

### DIFF
--- a/rocq-doc-manager/bin/rocq-ed/dune
+++ b/rocq-doc-manager/bin/rocq-ed/dune
@@ -1,0 +1,10 @@
+(executable
+ (public_name rocq-ed)
+ (name main)
+ (package rocq-doc-manager)
+ (preprocess (pps ppx_deriving.show))
+ (libraries
+  cmdliner
+  stdlib-extra
+  rocq-doc-manager.lib
+  uuseg.string))

--- a/rocq-doc-manager/bin/rocq-ed/dune_util.ml
+++ b/rocq-doc-manager/bin/rocq-ed/dune_util.ml
@@ -1,0 +1,26 @@
+open Stdlib_extra.Extra
+open Panic
+
+type config = {
+  no_build : bool;
+  jobs : int option;
+  display : string;
+}
+
+let get_args : config -> Filepath.t -> string list = fun config rocq_file ->
+  let args =
+    let display = Printf.sprintf "--display=%s" config.display in
+    let jobs = Option.map (Printf.sprintf "-j%i") config.jobs in
+    let jobs = match jobs with None -> [] | Some(s) -> [s] in
+    let no_build = if config.no_build then ["--no-build"] else [] in
+    let args = ["rocq"; "top"; display; "--toplevel=rocq-fake-repl"] in
+    args @ jobs @ no_build @ [rocq_file]
+  in
+  let temp = Filename.temp_file "temp" ".cli" in
+  match Cmdutil.(run ~cmd:"dune" ~stderr:Shell ~stdout:(File(temp)) args) with
+  | Error(_,s) ->
+      Fileutil.remove_file temp;
+      panic "Error: cannot get CLI arguments for %S (process %s)." rocq_file s
+  | Ok(())     ->
+  let lines = Fileutil.read_lines temp in
+  Fileutil.remove_file temp; lines

--- a/rocq-doc-manager/bin/rocq-ed/main.ml
+++ b/rocq-doc-manager/bin/rocq-ed/main.ml
@@ -1,0 +1,293 @@
+open Cmdliner
+open Panic
+
+let version = "dev"
+
+let non_dir_file_with_ext : string -> string Arg.conv = fun ext ->
+  let parse s =
+    let err s = Error(`Msg(s)) in
+    match Arg.(conv_parser non_dir_file s) with
+    | Ok(s) when s = "-"                     ->
+        err "\"-\" is not a valid Rocq source file name"
+    | Ok(s) when Filename.extension s <> ext ->
+        err (Printf.sprintf "\"%s\" does not have extension \"%s\"" s ext)
+    | res -> res
+  in
+  Arg.conv (parse, Arg.conv_printer Arg.non_dir_file)
+
+let rocq_file =
+  let doc =
+    "Path to an existing Rocq source file. The source file is expected to be \
+     managed by a dune project, so that appropriate CLI arguments can be \
+     automatically obtained."
+  in
+  let v_file = non_dir_file_with_ext ".v" in
+  Arg.(required & pos 0 (some v_file) None & info [] ~docv:"FILE" ~doc)
+
+let no_build =
+  let doc =
+    "Disables the building of dependencies before starting the editor. This \
+     option can be used to speed up the start-up in big projects, when the \
+     user knows that dependencies are up-to-date."
+  in
+  Arg.(value & flag & info ["no-build"] ~doc)
+
+let jobs =
+  let doc =
+    "Indicates that no more than $(docv) concurrent jobs should be run by \
+     $(b,dune) when building dependencies. If $(b,--no-build) is given, this \
+     option is a no-op."
+  in
+  Arg.(value & opt (some int) None & info ["j"; "jobs"] ~doc ~docv:"JOBS")
+
+let display =
+  let display =
+    let enum = ["progress"; "quiet"; "short"; "verbose"] in
+    Arg.enum (List.map (fun m -> (m, m)) enum)
+  in
+  let doc =
+    "Controls the display mode of $(b,dune) when building the dependencies \
+     of the file to be processed. If $(b,--no-build) is given, this option \
+     is a no-op. Available values are: $(b,progress) (updated status line), \
+     $(b,quiet) (only warnings and errors are displayed), $(b,short) (adds \
+     one line per command), and $(b,verbose) (full command line is printed)."
+  in
+  let i = Arg.info ["display"] ~docv:"MODE" ~doc in
+  Arg.(value & opt display "progress" & i)
+
+let dune_config =
+  let build no_build jobs display = Dune_util.{no_build; jobs; display} in
+  Term.(const build $ no_build $ jobs $ display)
+
+let init_cmd =
+  let doc =
+    "Starts a CLI editor session for the given Rocq source file. Note that \
+     when a session for a given source file is running, no other session can \
+     be started on the same file."
+  in
+  let term = Term.(const Protocol.init $ dune_config $ rocq_file) in
+  Cmd.(make (info "init" ~version ~doc) term)
+
+let stop_cmd =
+  let doc =
+    "Stop the running CLI editor session for the given Rocq source file."
+  in
+  let term = Term.(const Protocol.stop $ rocq_file) in
+  Cmd.(make (info "stop" ~version ~doc) term)
+
+let context_lines =
+  let doc =
+    "Print $(docv) lines of context before and after the cursor instead of \
+     printing the whole Rocq document."
+  in
+  Arg.(value & opt (some int) None & info ["C"; "context"] ~doc ~docv:"NUM")
+
+let status_cmd =
+  let doc =
+    "Print the current contents of the Rocq document, including the position \
+     of the cursor marked as $(b,<CURSOR>)."
+  in
+  let run context rocq_file =
+    match Protocol.client_request rocq_file Request.(Status({context})) with
+    | Ok(doc) -> Printf.printf "%s%!" doc
+  in
+  let term = Term.(const run $ context_lines $ rocq_file) in
+  Cmd.(make (info "status" ~version ~doc) term)
+
+let step_count =
+  let doc =
+    "Indicates the number of steps $(docv) that should be run (it is equal \
+     to 1 by default)."
+  in
+  Arg.(value & opt int 1 & info ["n"; "count"] ~doc ~docv:"NUM")
+
+let steps_cmd =
+  let doc =
+    "Step over the given number of document items (commands or blanks) in \
+     the Rocq document."
+  in
+  let run count rocq_file =
+    match Protocol.client_request rocq_file Request.(Steps({count})) with
+    | Ok(()) -> ()
+    | Error(s, i) ->
+        panic "Failed after processing %i items.\nError: %s." i s
+  in
+  let term = Term.(const run $ step_count $ rocq_file) in
+  Cmd.(make (info "steps" ~version ~doc) term)
+
+let command_text =
+  let doc =
+    "Specifies a chunk of Rocq code $(docv) to insert into the document. If \
+     it is not given, then the chunk of text is read from standard input"
+  in
+  Arg.(value & opt (some string) None & info ["t"; "text"] ~doc ~docv:"TEXT")
+
+let insert_cmd =
+  let doc =
+    "Insert the given chunk of Rocq code in the document, at the cursor. The \
+     cursor is advanced past the inserted chunk."
+  in
+  let run text rocq_file =
+    let text =
+      match text with Some(text) -> text | None ->
+      In_channel.input_all stdin
+    in
+    match Protocol.client_request rocq_file Request.(Insert({text})) with
+    | Ok(()) -> ()
+    | Error(s, left) -> panic "Error: could not process suffix %S.\n%s" left s
+  in
+  let term = Term.(const run $ command_text $ rocq_file) in
+  Cmd.(make (info "insert" ~version ~doc) term)
+
+let query_text =
+  let doc =
+    "Specifies the Rocq command to be run at the cursor."
+  in
+  Arg.(value & opt (some string) None & info ["t"; "text"] ~doc ~docv:"TEXT")
+
+let query_cmd =
+  let doc =
+    "Runs the given Rocq command at the cursor, and prints the resulting \
+     $(b,info) and $(b,notice) feedback to standard output."
+  in
+  let run text rocq_file =
+    let text =
+      match text with Some(text) -> text | None ->
+      In_channel.input_all stdin
+    in
+    match Protocol.client_request rocq_file Request.(Query({text})) with
+    | Ok(s) -> Printf.printf "%s%!" s
+    | Error(s, ()) -> panic "Error: %s." s
+  in
+  let term = Term.(const run $ query_text $ rocq_file) in
+  Cmd.(make (info "query" ~version ~doc) term)
+
+let deleted_item_count =
+  let doc =
+    "Indicates the number of items $(docv) that should be deleted after the \
+     cursor (it is equal to 1 by default)."
+  in
+  Arg.(value & opt int 1 & info ["n"; "count"] ~doc ~docv:"NUM")
+
+let delete_cmd =
+  let doc =
+    "Delete the given number of items (blanks or commands) after the cursor. \
+     The cursor is not moved in the operation."
+  in
+  let run count rocq_file =
+    match Protocol.client_request rocq_file Request.(Delete({count})) with
+    | Ok(()) -> ()
+    | Error(s, ()) -> panic "Error: %s." s
+  in
+  let term = Term.(const run $ deleted_item_count $ rocq_file) in
+  Cmd.(make (info "delete" ~version ~doc) term)
+
+let commit_cmd =
+  let doc =
+    "Commit the current state of the document to the source file."
+  in
+  let run rocq_file =
+    match Protocol.client_request rocq_file Request.Commit with
+    | Ok(()) -> ()
+    | Error(s, ()) -> panic "Error: unable to commit.\n%s" s
+  in
+  let term = Term.(const run $ rocq_file) in
+  Cmd.(make (info "commit" ~version ~doc) term)
+
+let goals_cmd =
+  let doc =
+    "Print the current proof state of the document, including the list of \
+     the goals currently in focus."
+  in
+  let run rocq_file =
+    match Protocol.client_request rocq_file Request.Goals with
+    | Ok(s) -> Printf.printf "%s%!" s
+  in
+  let term = Term.(const run $ rocq_file) in
+  Cmd.(make (info "goals" ~version ~doc) term)
+
+let undo_count =
+  let doc =
+    "Indicates the number of steps $(docv) that should be undone (it is \
+     equal to 1 by default)."
+  in
+  Arg.(value & opt int 1 & info ["n"; "count"] ~doc ~docv:"NUM")
+
+let undo_cmd =
+  let doc =
+    "Rolls back the cursor by the given number of document items (commands \
+     or blanks) in the Rocq document."
+  in
+  let run count rocq_file =
+    match Protocol.client_request rocq_file Request.(Undo({count})) with
+    | Ok(()) -> ()
+    | Error(s, ()) -> panic "Error: %s." s
+  in
+  let term = Term.(const run $ undo_count $ rocq_file) in
+  Cmd.(make (info "undo" ~version ~doc) term)
+
+let goto_pos =
+  let position =
+    let parse s =
+      match String.split_on_char ':' s with
+      | [line] ->
+          begin
+            match int_of_string_opt line with
+            | None ->
+                Error(`Msg("The line number must be an integer."))
+            | Some(line) when line < 1 ->
+                Error(`Msg("The line number should be at least 1."))
+            | Some(line) ->
+                Ok(line, None)
+          end
+      | [line; col] ->
+          begin
+            match int_of_string_opt line with
+            | None -> Error(`Msg("The line number must be an integer."))
+            | Some(line) when line < 1 ->
+                Error(`Msg("The line number should be at least 1."))
+            | Some(line) ->
+            match int_of_string_opt col with
+            | None -> Error(`Msg("The column number must be an integer."))
+            | Some(col) when col < 1 ->
+                Error(`Msg("The column number should be at least 1."))
+            | Some(col) -> Ok(line, Some(col))
+          end
+      | _ -> Error(`Msg("Format must be LINE or LINE:COLUMN."))
+    in
+    let print ff (line, col) =
+      Format.fprintf ff "%i" line;
+      Option.iter (Format.fprintf ff ":%i") col
+    in
+    Arg.conv (parse, print)
+  in
+  let doc = "Specifies the target position as $(docv)." in
+  Arg.(required & opt (some position) None & 
+    info ["p"; "pos"] ~doc ~docv:"LINE[:COLUMN]")
+
+let goto_cmd =
+  let doc =
+    "Moves the cursor to the item identified by the given line and column \
+     numbers."
+  in
+  let run (line, col) rocq_file =
+    match Protocol.client_request rocq_file Request.(Goto({line; col})) with
+    | Ok(()) -> ()
+    | Error(s, i) -> panic "Error: %s.\nThe cursor is now at index %i." s i
+  in
+  let term = Term.(const run $ goto_pos $ rocq_file) in
+  Cmd.(make (info "goto" ~version ~doc) term)
+
+let _ =
+  let cmds =
+    [ init_cmd; stop_cmd; status_cmd; steps_cmd; insert_cmd; query_cmd;
+      delete_cmd; commit_cmd; goals_cmd; undo_cmd; goto_cmd ]
+  in
+  let default = Term.(ret (const (`Help(`Pager, None)))) in
+  let default_info =
+    let doc =
+      "Command line Rocq editor."
+    in
+    Cmd.info "rocq-ed" ~version ~doc
+  in
+  exit (Cmd.eval (Cmd.group default_info ~default cmds))

--- a/rocq-doc-manager/bin/rocq-ed/panic.ml
+++ b/rocq-doc-manager/bin/rocq-ed/panic.ml
@@ -1,0 +1,41 @@
+(*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright: RefinedC developers and contributors 2020-2023
+ * Copyright: 2024 BlueRock Security, Inc.
+ *)
+
+(** Output and debugging utilities. *)
+
+(** Short name for a standard formatter. *)
+type 'a outfmt = ('a, Format.formatter, unit) format
+
+(** Short name for a standard formatter with continuation. *)
+type ('a, 'b) koutfmt = ('a, Format.formatter, unit, unit, unit, 'b) format6
+
+(** Format transformers (colors). *)
+let with_color k fmt = "\027[" ^^ k ^^ "m" ^^ fmt ^^ "\027[0m%!"
+
+let red fmt = with_color "31" fmt
+let gre fmt = with_color "32" fmt
+let yel fmt = with_color "33" fmt
+let blu fmt = with_color "34" fmt
+let mag fmt = with_color "35" fmt
+let cya fmt = with_color "36" fmt
+
+let info : 'a outfmt -> 'a = Format.printf
+
+(** [wrn fmt] outputs the warning message specified by [fmt] (and the attached
+    arguments) to [stderr]. A newline is automatically added at the end of the
+    message, and [stderr] is also flushed. *)
+let wrn : 'a outfmt -> 'a = fun fmt ->
+  Format.eprintf (yel (fmt ^^ "\n%!"))
+
+(** [err] is the same as [wrn], but outputs an error message. *)
+let err : 'a outfmt -> 'a = fun fmt ->
+  Format.eprintf (red (fmt ^^ "\n%!"))
+
+(** [panic fmt] outputs the error message specified by [fmt] (and the attached
+    arguments) to [stderr], and interupts the program with [exit 1]. A newline
+    is automatically inserted, and [stderr] is also flushed. *)
+let panic : ('a,'b) koutfmt -> 'a = fun fmt ->
+  Format.kfprintf (fun _ -> exit 1) Format.err_formatter (red (fmt ^^ "\n%!"))

--- a/rocq-doc-manager/bin/rocq-ed/protocol.ml
+++ b/rocq-doc-manager/bin/rocq-ed/protocol.ml
@@ -1,0 +1,143 @@
+open Stdlib_extra.Extra
+open Panic
+
+let daemonize : ?log:Filepath.t -> unit -> int = fun ?(log="/dev/null") _ ->
+  (fun f -> Unix.handle_unix_error f ()) @@ fun _ ->
+  (* Detatch the process from the terminal. *)
+  let pid = Unix.fork () in
+  if pid > 0 then exit 0;
+  let _ = Unix.setsid () in
+  let pid = Unix.fork () in
+  if pid > 0 then exit 0;
+  (* Change the stdout and stderr descriptors to write to the log. *)
+  let log_fd = Unix.openfile log Unix.[O_WRONLY; O_CREAT; O_APPEND] 0o640 in
+  Unix.dup2 log_fd Unix.stdout;
+  Unix.dup2 log_fd Unix.stderr;
+  Unix.close log_fd;
+  (* Change the stdin descriptor to read from /dev/null. *)
+  let null_fd = Unix.openfile "/dev/null" Unix.[O_RDONLY] 0 in
+  Unix.dup2 null_fd Unix.stdin;
+  Unix.close null_fd;
+  (* Return the PID of the daemon. *)
+  Unix.handle_unix_error Unix.getpid ()
+
+let init : Dune_util.config -> Filepath.t -> unit = fun config rocq_file ->
+  assert (Sys.file_exists rocq_file);
+  assert (Filename.extension rocq_file = ".v");
+  (* Changing the working directory to the file's directory. *)
+  let dir = Filename.dirname rocq_file in
+  let rocq_file = Filename.basename rocq_file in
+  Sys.chdir dir;
+  (* Create the data directory, which also locks the session for the file. *)
+  let data_dir = rocq_file ^ ".rocq-ed" in
+  let _ =
+    try Sys.mkdir data_dir 0o755 with Sys_error(s) ->
+    if String.ends_with ~suffix:"File exists" s then
+      panic "Error: a session is already running for that file.";
+    panic "Error: %s." s
+  in
+  (* Get the CLI arguments and create create a document. *)
+  let args = Dune_util.get_args config rocq_file in
+  let d = Document.init ~args ~file:rocq_file in
+  match Document.load_file d with
+  | Error(s, _) -> panic "Error: unable to load the file (%s)." s
+  | Ok(())      ->
+  (* Prepare the communication pipes. *)
+  let req_fifo = Filename.concat data_dir "req.fifo" in
+  Unix.mkfifo req_fifo 0o640;
+  let res_fifo = Filename.concat data_dir "res.fifo" in
+  Unix.mkfifo res_fifo 0o640;
+  (* Daemonize the process, and write its PID to a file. *)
+  let log_file = Filename.concat data_dir "log" in
+  let pid = daemonize ~log:log_file () in
+  let pid_file = Filename.concat data_dir "daemon.pid" in
+  Fileutil.write_lines pid_file [Printf.sprintf "%i" pid];
+  (* Logging function (will end up in the log file). *)
+  let log fmt =
+    let time = Unix.gettimeofday () in
+    Format.printf ("%f: " ^^ fmt ^^ "\n%!") time
+  in
+  log "Started the daemon (pid %i)" pid;
+  (* Single request handler. *)
+  let handle_request () =
+    log "Running request handler.";
+    let req =
+      In_channel.with_open_text req_fifo @@ fun ic ->
+      log "Waiting for a request.";
+      Marshal.from_channel ic
+    in
+    log "Request [%a] received." Request.pp req;
+    let is_stop = Request.is_stop req in
+    let res = Request.run d req in
+    let _ =
+      match res with
+      | Ok(_) -> log "Request successful."
+      | Error(s, _) ->
+      match String.split_on_char '\n' (String.trim s) with
+      | []     -> log "Request error."
+      | [line] -> log "Request error [%s]." line
+      | lines  ->
+      log "Request error.";
+      List.iter (Printf.printf "> %s\n%!") lines
+    in
+    if is_stop then Unix.unlink pid_file;
+    let _ =
+      Out_channel.with_open_text res_fifo @@ fun oc ->
+      log "Sending response.";
+      Marshal.to_channel oc res [];
+      Out_channel.flush oc
+    in
+    log "Response sent.";
+    not is_stop
+  in
+  (* Run the request loop. *)
+  log "Running the request loop.";
+  let rec loop () =
+    let keep_going = handle_request () in
+    if keep_going then loop ()
+  in
+  loop ();
+  (* Cleanup and shutdown since a stop request must have been received. *)
+  log "Reached deamon shutdown.";
+  exit 0
+
+let client_request : type a b. Filepath.t -> (a, b) Request.t ->
+    (a, string * b) Result.t = fun rocq_file req ->
+  assert (Sys.file_exists rocq_file);
+  assert (Filename.extension rocq_file = ".v");
+  (* Check that the daemon is running. *)
+  let data_dir = rocq_file ^ ".rocq-ed" in
+  let pid_file = Filename.concat data_dir "daemon.pid" in
+  if not (Sys.file_exists data_dir) then
+    panic "Error: no active session for %S." rocq_file;
+  if not (Sys.file_exists pid_file) then
+    panic "Error: session daemon is not ready for %S." rocq_file;
+  (* Attempt to take the client lock. *)
+  let lock_dir = Filename.concat data_dir "client.lock" in
+  let _ =
+    try Sys.mkdir lock_dir 0o755 with Sys_error(s) ->
+    if String.ends_with ~suffix:"File exists" s then
+      panic "Error: a request is already in progress.";
+    panic "Error: %s." s
+  in
+  (* Run the request. *)
+  let req_fifo = Filename.concat data_dir "req.fifo" in
+  let res_fifo = Filename.concat data_dir "res.fifo" in
+  let _ =
+    Out_channel.with_open_text req_fifo @@ fun oc ->
+    Marshal.to_channel oc req [];
+    Out_channel.flush oc
+  in
+  let res = In_channel.with_open_text res_fifo Marshal.from_channel in
+  (* Release the lock, and return the response. *)
+  Unix.rmdir lock_dir; res
+
+let stop : Filepath.t -> unit = fun rocq_file ->
+  ignore (client_request rocq_file Request.Stop);
+  let data_dir = rocq_file ^ ".rocq-ed" in
+  let req_fifo = Filename.concat data_dir "req.fifo" in
+  let res_fifo = Filename.concat data_dir "res.fifo" in
+  List.iter Unix.unlink [req_fifo; res_fifo];
+  let log_file = Filename.concat data_dir "log" in
+  if Sys.file_exists log_file then Unix.unlink log_file;
+  Unix.rmdir data_dir

--- a/rocq-doc-manager/bin/rocq-ed/request.ml
+++ b/rocq-doc-manager/bin/rocq-ed/request.ml
@@ -1,0 +1,317 @@
+open Stdlib_extra.Extra
+
+type empty = |
+
+type (_, _) t =
+  | Stop : (unit, empty) t
+  | Status : {context : int option} -> (string, empty) t
+  | Steps : {count : int} -> (unit, int) t
+  | Insert : {text : string} -> (unit, string) t
+  | Query : {text : string} -> (string, unit) t
+  | Delete : {count : int} -> (unit, unit) t
+  | Commit : (unit, unit) t
+  | Goals : (string, empty) t
+  | Undo : {count : int} -> (unit, unit) t
+  | Goto : {line: int; col: int option} -> (unit, int) t
+
+let is_stop : type a b. (a, b) t -> bool = fun r ->
+  match r with Stop -> true | _ -> false
+
+let pp : type a b. (a, b) t Format.pp = fun ff r ->
+  match r with
+  | Stop ->
+      Format.fprintf ff "Stop"
+  | Status({context = None}) ->
+      Format.fprintf ff "Status({context = None})"
+  | Status({context = Some(i)}) ->
+      Format.fprintf ff "Status({context = %i})" i
+  | Steps({count}) ->
+      Format.fprintf ff "Steps({count = %i})" count
+  | Insert({text}) ->
+      Format.fprintf ff "Insert({text = %S})" text
+  | Query({text}) ->
+      Format.fprintf ff "Query({text = %S})" text
+  | Delete({count}) ->
+      Format.fprintf ff "Delete({count = %i})" count
+  | Commit ->
+      Format.fprintf ff "Commit"
+  | Goals ->
+      Format.fprintf ff "Goals"
+  | Undo({count}) ->
+      Format.fprintf ff "Undo({count = %i})" count
+  | Goto({line; col = None}) ->
+      Format.fprintf ff "Goto({line = %i; col = None})" line
+  | Goto({line; col = Some(col)}) ->
+      Format.fprintf ff "Goto({line = %i; col = %i})" line col
+
+let lines : string -> string array = fun s ->
+  let lines = Dynarray.create () in
+  let line_start = ref 0 in
+  let handle_char i c =
+    if c = '\n' then begin
+      let start = !line_start in
+      let line = String.sub s start (i - start + 1) in
+      Dynarray.add_last lines line;
+      line_start := i + 1
+    end
+  in
+  String.iteri handle_char s;
+  let start = !line_start in
+  let len = String.length s in
+  if start != len then begin
+    let line = String.sub s start (len - start) in
+    Dynarray.add_last lines line
+  end;
+  Dynarray.to_array lines
+
+let newline_terminated : string -> bool =
+  String.ends_with ~suffix:"\n"
+
+let run_status d ~context =
+  let prefix =
+    let prefix = List.rev (Document.rev_prefix d) in
+    let filter (Document.{kind; text; _} : Document.processed_item) =
+      match kind with `Ghost(_) -> None | _ -> Some(text)
+    in
+    String.concat "" (List.filter_map filter prefix)
+  in
+  let suffix =
+    let suffix = Document.suffix d in
+    let filter (Document.{kind; text} : Document.unprocessed_item) =
+      match kind with `Ghost(_) -> None | _ -> Some(text)
+    in
+    String.concat "" (List.filter_map filter suffix)
+  in
+  (* Invariant: all lines end with a newline. *)
+  let (prefix, cursor_line, suffix) =
+    let prefix = lines prefix in
+    let suffix = lines suffix in
+    let (prefix, cursor_prefix) =
+      match Array.length prefix with 0 -> ([||], "") | n ->
+      let last = prefix.(n - 1) in
+      match newline_terminated last with
+      | true  -> (prefix, "") 
+      | false -> (Array.sub prefix 0 (n - 1), last)
+    in
+    let (cursor_suffix, suffix) =
+      match Array.length suffix with 0 -> ("\n", [||]) | n ->
+      let (first, suffix) = (suffix.(0), Array.sub suffix 1 (n - 1)) in
+      let first = first ^ if newline_terminated first then "" else "\n" in
+      (first, suffix)
+    in
+    let len_suffix = Array.length suffix in
+    if len_suffix <> 0 then begin
+      let last = suffix.(len_suffix - 1) in
+      if not (newline_terminated last) then
+        suffix.(len_suffix - 1) <- last ^ "\n"
+    end;
+    (prefix, cursor_prefix ^ "<CURSOR>" ^ cursor_suffix, suffix)
+  in
+  let lines = Array.concat [prefix; [|cursor_line|]; suffix] in
+  let cursor_line = Array.length prefix in
+  let nb_lines = Array.length lines in
+  let b = Buffer.create 73 in
+  let _ =
+    match context with
+    | None ->
+        for i = 0 to nb_lines - 1 do
+          Buffer.add_string b (Printf.sprintf "%4i| %s" (i+1) lines.(i))
+        done
+    | Some(i) ->
+        let i1 = max 0 (cursor_line - i) in
+        let i2 = min (cursor_line + i) (nb_lines - 1) in
+        for i = i1 to i2 do
+          Buffer.add_string b (Printf.sprintf "%4i| %s" (i+1) lines.(i))
+        done
+  in
+  Ok(Buffer.contents b)
+
+let run_steps d ~count =
+  match Document.run_steps d ~count with
+  | Ok(()) -> Ok(())
+  | Error(s, (i, None)) -> Error(s, i)
+  | Error(_, (i, Some(s, _))) -> Error(s, i)
+  | exception Invalid_argument(s) -> Error(s, 0)
+
+let run_insert d ~text =
+  let (sentences, res) = Document.split_sentences d ~text in
+  let rec run_sentences (sentences : Document.sentence list) =
+    match sentences with
+    | [] -> ([], None)
+    | Document.{kind; text} as s :: sentences ->
+    let err =
+      match kind with
+      | `Blanks ->
+          begin
+            try Document.insert_blanks d ~text; None with
+            | Invalid_argument(s) -> Some(s)
+          end
+      | `Command(_) ->
+          begin
+            match Document.insert_command d ~text with
+            | Ok(_) -> None
+            | Error(s, _) -> Some(s)
+            | exception Invalid_argument(s) -> Some(s)
+          end
+    in
+    match err with
+    | None -> run_sentences sentences
+    | _ -> (s :: sentences, err)
+  in
+  let get_text (d : Document.sentence) = d.Document.text in
+  match (run_sentences sentences, res) with
+  | ((_, None), Ok(())) -> Ok(())
+  | ((_, None), Error(s, remaining)) -> Error(s, remaining)
+  | ((sentences, Some(s)), Ok(())) ->
+      let remaining = List.map get_text sentences in
+      let remaining = String.concat "" remaining in
+      Error(s, remaining)
+  | ((sentences, Some(s)), Error(_, remaining)) ->
+      let remaining = List.map get_text sentences @ [remaining] in
+      let remaining = String.concat "" remaining in
+      Error(s, remaining)
+
+let run_query d ~text =
+  let text = String.trim text in
+  match Document.query_text_all d ~text with
+  | Ok(ls) -> Ok(String.concat "\n" ls)
+  | Error(s) -> Error(s, ())
+
+let run_delete d ~count =
+  try Ok(Document.clear_suffix ~count d) with
+  | Invalid_argument(s) -> Error(s, ())
+
+let run_commit d =
+  let res = Document.commit d in
+  Result.map_error (fun s -> (s, ())) res
+
+let run_goals d =
+  match Document.query d ~text:"Locate nat." with
+  | Error(_) -> assert false
+  | Ok(data) ->
+  match data.Rocq_toplevel.proof_state with
+  | None -> Ok("Not currently in a proof.")
+  | Some(p) ->
+  let b = Buffer.create 73 in
+  let add_focused i goal =
+    Buffer.add_string b (Printf.sprintf "Goal %i:\n" (i+1));
+    let goal_line s = Buffer.add_string b ("  " ^ s ^ "\n") in
+    List.iter goal_line (String.split_on_char '\n' (String.trim goal))
+  in
+  List.iteri add_focused p.Rocq_toplevel.focused_goals;
+  let Rocq_toplevel.{given_up_goals; shelved_goals; unfocused_goals; _} = p in
+  let unfocused_goals = List.fold_left (+) 0 unfocused_goals in
+  let print cat n =
+    if n <> 0 then Buffer.add_string b (Printf.sprintf "%s: %i\n" cat n)
+  in
+  print "Given up goals" given_up_goals;
+  print "Shelved goals" shelved_goals;
+  print "Unfocused goals" unfocused_goals;
+  Ok(Buffer.contents b)
+
+let run_undo d ~count =
+  let cursor_index = Document.cursor_index d in
+  let index = cursor_index - count in
+  if index < 0 then
+    Error("invalid count (not enough items to undo)", ())
+  else
+    Ok(Document.revert_before d ~index)
+
+let run_goto d ~line ~col =
+  assert (line > 0 && Stdlib.Option.value ~default:1 col > 0);
+  (* Collect the text of all document items. *)
+  let items =
+    let get_text (Document.{kind; text; _} : Document.processed_item) =
+      match kind with `Ghost(_) -> "" | _ -> text
+    in
+    let prefix = List.rev_map get_text (Document.rev_prefix d) in
+    let get_text (Document.{kind; text} : Document.unprocessed_item) =
+      match kind with `Ghost(_) -> "" | _ -> text
+    in
+    let suffix = List.map get_text (Document.suffix d) in
+    prefix @ suffix
+  in
+  (* Get the line representation of the document. *)
+  let lines = lines (String.concat "" items) in
+  let nb_lines = Array.length lines in
+  (* Check that there are enough lines. *)
+  match nb_lines < line with
+  | true  -> Error("no item on the given line", Document.cursor_index d)
+  | false ->
+  (* Finding the byte offset of the start of the line, and the line length. *)
+  let line_start_off =
+    let off = ref 0 in
+    for i = 0 to line - 2 do off := !off + String.length lines.(i) done; !off
+  in
+  let line_len = String.length lines.(line - 1) in
+  let line_end_off = line_start_off + line_len - 1 in
+  (* Collecting the candidate items, with their index. *)
+  let rec collect acc ~off ~index items =
+    match items with [] -> List.rev acc | item :: items ->
+    let len = String.length item in
+    let next_off = off + len in
+    let continue acc =
+      collect acc ~off:next_off ~index:(index + 1) items
+    in
+    if next_off < line_start_off then
+      continue acc
+    else if line_start_off <= next_off && off <= line_end_off then
+      continue ((item, index, off, next_off - 1) :: acc)
+    else
+      List.rev acc
+  in
+  let candidates = collect [] ~off:0 ~index:0 items in
+  assert (List.length candidates > 0);
+  (* Trim excess bits of candidates (falling on the previous or next line). *)
+  let trim (item, index, off_start, off_end) =
+    let trim_l = max 0 (line_start_off - off_start) in
+    let trim_r = max 0 (off_end - line_end_off) in
+    let len = String.length item - trim_l - trim_r in
+    (String.sub item trim_l len, index, off_start, off_end)
+  in
+  let candidates = List.map trim candidates in
+  let _ =
+    let line_text = List.map (fun (text, _, _, _) -> text) candidates in
+    let line_text = String.concat "" line_text in
+    assert (line_text = lines.(line - 1))
+  in
+  (* Select the index. *)
+  let index =
+    match col with
+    | None      ->
+        let (_, index, _, _) = List.hd candidates in
+        Ok(index)
+    | Some(col) ->
+        let rec find_col n candidates =
+          match candidates with
+          | [] ->
+              Error("no item on the given column", Document.cursor_index d)
+          | (text, index, _, _) :: candidates ->
+              let next_n =
+                Uuseg_string.fold_utf_8 `Grapheme_cluster
+                  (fun n _ -> n + 1) n text
+              in
+              if col <= next_n then Ok(index) else find_col next_n candidates
+        in
+        find_col 0 candidates
+  in
+  match index with
+  | Error(msg, i) -> Error(msg, i)
+  | Ok(index)  ->
+  match Document.go_to d ~index with
+  | Ok(()) -> Ok(())
+  | Error(msg, _) -> Error(msg, Document.cursor_index d)
+
+let run : type a b. Document.t -> (a, b) t ->
+    (a, string * b) Result.t = fun d r ->
+  match r with
+  | Stop              -> Ok(())
+  | Status({context}) -> run_status d ~context
+  | Steps({count})    -> run_steps d ~count
+  | Insert({text})    -> run_insert d ~text
+  | Query({text})     -> run_query d ~text
+  | Delete({count})   -> run_delete d ~count
+  | Commit            -> run_commit d
+  | Goals             -> run_goals d
+  | Undo({count})     -> run_undo d ~count
+  | Goto({line; col}) -> run_goto d ~line ~col

--- a/rocq-doc-manager/tests/rocq-ed/basic.t
+++ b/rocq-doc-manager/tests/rocq-ed/basic.t
@@ -1,0 +1,108 @@
+  $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
+  $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
+  $ export DUNE_CACHE=disabled
+
+  $ cat > test.v <<EOF
+  > (* Test file. *)
+  > Theorem test : forall x : nat, x = x.
+  > Proof.
+  >   intro x.
+  >   reflexivity.
+  > Qed.
+  > 
+  > (* END *)
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using rocq 0.11)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rocq.theory
+  >  (name text))
+  > EOF
+
+  $ rocq-ed init test.v
+  $ find test.v.rocq-ed | LC_ALL=C sort
+  test.v.rocq-ed
+  test.v.rocq-ed/daemon.pid
+  test.v.rocq-ed/log
+  test.v.rocq-ed/req.fifo
+  test.v.rocq-ed/res.fifo
+  $ rocq-ed status test.v
+     1| <CURSOR>(* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof.
+     4|   intro x.
+     5|   reflexivity.
+     6| Qed.
+     7| 
+     8| (* END *)
+  $ rocq-ed status -C 0 test.v
+     1| <CURSOR>(* Test file. *)
+  $ rocq-ed status -C 1 test.v
+     1| <CURSOR>(* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+  $ rocq-ed status -C 2 test.v
+     1| <CURSOR>(* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof.
+  $ rocq-ed steps --count 5 test.v
+  $ rocq-ed status test.v
+     1| (* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof.
+     4|   <CURSOR>intro x.
+     5|   reflexivity.
+     6| Qed.
+     7| 
+     8| (* END *)
+  $ rocq-ed undo --count 5 test.v
+  $ rocq-ed status test.v
+     1| <CURSOR>(* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof.
+     4|   intro x.
+     5|   reflexivity.
+     6| Qed.
+     7| 
+     8| (* END *)
+  $ rocq-ed steps --count 5 test.v
+  $ rocq-ed status -C 0 test.v
+     4|   <CURSOR>intro x.
+  $ rocq-ed status -C 1 test.v
+     3| Proof.
+     4|   <CURSOR>intro x.
+     5|   reflexivity.
+  $ rocq-ed status -C 2 test.v
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof.
+     4|   <CURSOR>intro x.
+     5|   reflexivity.
+     6| Qed.
+  $ rocq-ed steps --count 3 test.v
+  $ rocq-ed status test.v
+     1| (* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof.
+     4|   intro x.
+     5|   reflexivity.<CURSOR>
+     6| Qed.
+     7| 
+     8| (* END *)
+  $ rocq-ed steps --count 3 test.v
+  $ rocq-ed status test.v
+     1| (* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof.
+     4|   intro x.
+     5|   reflexivity.
+     6| Qed.
+     7| 
+     8| (* END *)
+     9| <CURSOR>
+  $ rocq-ed stop test.v
+  $ find test.v.rocq-ed
+  find: 'test.v.rocq-ed': No such file or directory
+  [1]

--- a/rocq-doc-manager/tests/rocq-ed/goto.t
+++ b/rocq-doc-manager/tests/rocq-ed/goto.t
@@ -1,0 +1,87 @@
+  $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
+  $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
+  $ export DUNE_CACHE=disabled
+  $ export TERM=dumb
+
+  $ cat > test.v <<EOF
+  > (* Test file. *)
+  > Theorem test : forall x : nat, x = x.
+  > Proof. intro x. reflexivity. Qed.
+  > 
+  > (* END *)
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using rocq 0.11)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rocq.theory
+  >  (name text))
+  > EOF
+
+  $ rocq-ed init test.v
+  $ rocq-ed goto --pos 0 test.v
+  Usage: rocq-ed goto [--help] --pos=LINE[:COLUMN] [OPTION]… FILE
+  rocq-ed: option '--pos': The line number should be at least 1.
+  [124]
+  $ rocq-ed goto --pos 0:1 test.v
+  Usage: rocq-ed goto [--help] --pos=LINE[:COLUMN] [OPTION]… FILE
+  rocq-ed: option '--pos': The line number should be at least 1.
+  [124]
+  $ rocq-ed goto --pos 1:0 test.v
+  Usage: rocq-ed goto [--help] --pos=LINE[:COLUMN] [OPTION]… FILE
+  rocq-ed: option '--pos': The column number should be at least 1.
+  [124]
+  $ rocq-ed goto --pos 6:1 test.v
+  Error: no item on the given line.
+  The cursor is now at index 0.
+  [1]
+  $ rocq-ed goto --pos 1:18 test.v
+  Error: no item on the given column.
+  The cursor is now at index 0.
+  [1]
+  $ rocq-ed goto --pos 1:1 test.v
+  $ rocq-ed status test.v
+     1| <CURSOR>(* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof. intro x. reflexivity. Qed.
+     4| 
+     5| (* END *)
+  $ rocq-ed goto --pos 1:17 test.v
+  $ rocq-ed status test.v
+     1| <CURSOR>(* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof. intro x. reflexivity. Qed.
+     4| 
+     5| (* END *)
+  $ rocq-ed goto --pos 2:1 test.v
+  $ rocq-ed status test.v
+     1| (* Test file. *)
+     2| <CURSOR>Theorem test : forall x : nat, x = x.
+     3| Proof. intro x. reflexivity. Qed.
+     4| 
+     5| (* END *)
+  $ rocq-ed goto --pos 3:1 test.v
+  $ rocq-ed status test.v
+     1| (* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| <CURSOR>Proof. intro x. reflexivity. Qed.
+     4| 
+     5| (* END *)
+  $ rocq-ed goto --pos 3:8 test.v
+  $ rocq-ed status test.v
+     1| (* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof. <CURSOR>intro x. reflexivity. Qed.
+     4| 
+     5| (* END *)
+  $ rocq-ed goto --pos 3:34 test.v
+  $ rocq-ed status test.v
+     1| (* Test file. *)
+     2| Theorem test : forall x : nat, x = x.
+     3| Proof. intro x. reflexivity. Qed.<CURSOR>
+     4| 
+     5| (* END *)
+  $ rocq-ed stop test.v

--- a/rocq-doc-manager/tests/rocq-ed/proof.t
+++ b/rocq-doc-manager/tests/rocq-ed/proof.t
@@ -1,0 +1,126 @@
+  $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
+  $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
+  $ export DUNE_CACHE=disabled
+
+  $ cat > test.v <<EOF
+  > Theorem test : forall x : nat, True /\ x = x.
+  > Proof.
+  > Admitted.
+  > EOF
+
+  $ cat > dune-project <<EOF
+  > (lang dune 3.21)
+  > (using rocq 0.11)
+  > EOF
+
+  $ cat > dune <<EOF
+  > (rocq.theory
+  >  (name text))
+  > EOF
+
+  $ rocq-ed init test.v
+  $ rocq-ed goals test.v
+  Not currently in a proof.
+  $ rocq-ed steps --count 3 test.v
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.<CURSOR>
+     3| Admitted.
+  $ rocq-ed goals test.v
+  Goal 1:
+    ============================
+    forall x : nat, True /\ x = x
+  $ rocq-ed insert --text $'\n  intros x; split.' test.v
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.
+     3|   intros x; split.<CURSOR>
+     4| Admitted.
+  $ rocq-ed goals test.v
+  Goal 1:
+    x : nat
+    ============================
+    True
+  Goal 2:
+    x : nat
+    ============================
+    x = x
+  $ rocq-ed insert --text $'\n  - fail.\n  -' test.v
+  Error: could not process suffix "fail.\n  -".
+  Tactic failure.
+  [1]
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.
+     3|   intros x; split.
+     4|   - <CURSOR>
+     5| Admitted.
+  $ rocq-ed insert --text $'constructor.\n  - ' test.v
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.
+     3|   intros x; split.
+     4|   - constructor.
+     5|   - <CURSOR>
+     6| Admitted.
+  $ rocq-ed query --text "About eq_refl." test.v
+  eq_refl : forall {A : Type} {x : A}, x = x
+  
+  eq_refl is template universe polymorphic
+  Arguments eq_refl {A}%_type_scope {x}, [_] _
+  Expands to: Constructor Corelib.Init.Logic.eq_refl
+  Declared in library Corelib.Init.Logic, line 379, characters 4-11
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.
+     3|   intros x; split.
+     4|   - constructor.
+     5|   - <CURSOR>
+     6| Admitted.
+  $ rocq-ed insert --text "reflexivity." test.v
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.
+     3|   intros x; split.
+     4|   - constructor.
+     5|   - reflexivity.<CURSOR>
+     6| Admitted.
+  $ rocq-ed steps --count 2 test.v
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.
+     3|   intros x; split.
+     4|   - constructor.
+     5|   - reflexivity.
+     6| Admitted.<CURSOR>
+  $ cat test.v
+  Theorem test : forall x : nat, True /\ x = x.
+  Proof.
+  Admitted.
+  $ rocq-ed commit test.v
+  $ cat test.v
+  Theorem test : forall x : nat, True /\ x = x.
+  Proof.
+    intros x; split.
+    - constructor.
+    - reflexivity.
+  Admitted.
+  $ rocq-ed insert --text $'\n\nGoal True /\ True.\nProof.\n  split.' test.v
+  $ rocq-ed insert --text $' 1: shelve.' test.v
+  $ rocq-ed status test.v
+     1| Theorem test : forall x : nat, True /\ x = x.
+     2| Proof.
+     3|   intros x; split.
+     4|   - constructor.
+     5|   - reflexivity.
+     6| Admitted.
+     7| 
+     8| Goal True /\ True.
+     9| Proof.
+    10|   split. 1: shelve.<CURSOR>
+  $ rocq-ed goals test.v
+  Goal 1:
+    ============================
+    True
+  Shelved goals: 1
+  $ rocq-ed stop test.v


### PR DESCRIPTION
Test cases should give an idea of how the tool is used.

It is possible to run the tool in the workspace, but `rocq-ed init` needs to be run as follows, assuming `$WORKSPACE` is an absolute path to where your workspace root is.
```
PATH=$WORKSPACE/_build/install/default/bin:$PATH OCAMLPATH=$WORKSPACE/_build/install/default/lib $WORKSPACE/_build/default/fmdeps/rocq-agent-toolkit/rocq-doc-manager/bin/rocq-ed/main.exe init path/to/file.v
```
Subsequent commands can be run with `dune exec -- rocq-ed ...`.