### PR TITLE
rocq-eq: Add missing opam dependency

### DIFF
--- a/rocq-doc-manager/dune-project
+++ b/rocq-doc-manager/dune-project
@@ -12,6 +12,7 @@
  (synopsis "Tool for programatically editing Rocq source files")
  (depends
   jsonrpc-tp
+  stdlib-extra
   rocq-simple-api))
 
 (subst disabled)

--- a/rocq-doc-manager/rocq-doc-manager.opam
+++ b/rocq-doc-manager/rocq-doc-manager.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/SkylabsAI/skylabs-fm/issues"
 depends: [
   "dune" {>= "3.21"}
   "jsonrpc-tp"
+  "stdlib-extra"
   "rocq-simple-api"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Fix failure in
https://github.com/SkyLabsAI/ci/actions/runs/25035235536/job/73325490269#step:5:2516.

Root cause: rocq-eq's dune file
`fmdeps/rocq-agent-toolkit/rocq-doc-manager/bin/rocq-ed/dune` depends on `stdlib-extra` OCaml library, so the `.opam` file needs to depend on the matching Opam package.