### PR TITLE
add commands to `rocq-ed` to enable code-block based navigation

### DIFF
--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,27 @@
+
+Context:
+ - in fmdeps/rocq-agent-toolkit/rocq-doc-manager/lib is the ml implementation of a document manager
+ - the document manager is used by `rocq-ed` which is implemented here `rocq-agent-toolkit/rocq-doc-manager/bin/rocq-ed`
+
+Goal:
+ - implement the following user commands:
+   - goto-lemma NAME: move the cursor to a lemma named `NAME`, whether it be declared as a lemma, theorem, etc.
+   - lemma-end NAME: go to the last command that is a part of the lemma declaration or its proof
+   - next-lemma: jump to the next lemma
+   - goto-section NAME: move cursor to the beginning of a section named `NAME`
+   - section-end NAME:  move cursor to the end of the section `NAME`
+ - make the necessary changes in the document manager
+
+Output:
+   - a number of test cases demonstrating the purpose of the commands listed above
+   - file `proposal.md`:
+     - a plan for changing the document manager to allow the implementation of above commands
+     - a plan for implementing the commands in `rocq-ed`
+
+Limitations:
+  - the only files that can be written to disk are `proposal.md` and the test cases produced for `rocq-ed`
+
+References:
+- https://github.com/SkyLabsAI/rocq-agent-toolkit/blob/51ae58becd23c2c89decef5de2a63d6a862b4e0b/rocq-doc-manager/lib/document.mli#L85
+- https://github.com/SkyLabsAI/rocq-agent-toolkit/blob/51ae58becd23c2c89decef5de2a63d6a862b4e0b/ocaml-rocq-simple-api/lib/api/rocq_vernac_entry.mli#L28
+- https://github.com/SkyLabsAI/rocq/blob/bef7df542ab174b83b2f25c3378fe7ef8d9dba59/vernac/vernacexpr.mli#L404-L521

--- a/proposal.md
+++ b/proposal.md
@@ -1,0 +1,122 @@
+# Proposal: named navigation for `rocq-ed`
+
+## Semantics to implement
+
+- `goto-lemma NAME FILE`: move the cursor to the command that starts the first theorem-style declaration whose declared id is exactly `NAME` (`Lemma`, `Theorem`, `Fact`, `Remark`, `Property`, `Proposition`, `Corollary`).
+- `lemma-end NAME FILE`: move the cursor to the final command belonging to that declaration/proof, normally `Qed.`, `Defined.`, or `Admitted.`. The cursor is placed before that final command, matching the existing item-index navigation model.
+- `next-lemma FILE`: move to the first theorem-style declaration whose start item is strictly after the current cursor index.
+- `goto-section NAME FILE`: move to the `Section NAME.` command.
+- `section-end NAME FILE`: move to the matching `End NAME.` command, respecting nested sections/modules.
+
+All commands should use exact unqualified names, skip commands wrapped in `Fail`/`Succeed`, and use the existing `with_auto_print` behavior used by `goto`.
+
+## Document manager changes
+
+1. Add semantic navigation helpers to `rocq-doc-manager/lib/document.{mli,ml}`.
+
+   Proposed public data types:
+
+   ```ocaml
+   type lemma_kind =
+     [ `Theorem | `Lemma | `Fact | `Remark | `Property
+     | `Proposition | `Corollary ]
+
+   type lemma_span = {
+     name : string;
+     names : string list;      (* all names declared by the start command *)
+     kind : lemma_kind;
+     start_index : int;        (* declaration command *)
+     end_index : int option;   (* final proof command, if found *)
+   }
+
+   type section_span = {
+     name : string;
+     start_index : int;        (* Section command *)
+     end_index : int option;   (* matching End command *)
+   }
+
+   val lemma_spans : t -> lemma_span list
+   val section_spans : t -> section_span list
+   val find_lemma : t -> name:string -> lemma_span option
+   val find_next_lemma : t -> lemma_span option
+   val find_section : t -> name:string -> section_span option
+   ```
+
+2. Internally, scan `List.rev (rev_prefix d) @ suffix d` with stable document indices. Reuse each processed item index and compute suffix indices from `cursor_index d`.
+
+3. Identify lemma starts by pattern-matching the attached vernacular AST:
+
+   ```ocaml
+   match snd command.CAst.v with
+   | Vernacexpr.VernacSynPure
+       (Vernacexpr.VernacStartTheoremProof (kind, proof_exprs)) -> ...
+   | _ -> None
+   ```
+
+   Extract ids from `proof_exprs`. Map `Decls.theorem_kind` to `lemma_kind`. Ignore `ControlFail` and `ControlSucceed`.
+
+4. Compute `lemma_span.end_index` by scanning forward from the start command until the first proof-closing command:
+
+   - `VernacSynPure (VernacEndProof _)` for `Qed.`, `Defined.`, and `Admitted.`
+   - optionally `VernacSynPure (VernacExactProof _)` if the current Rocq parser uses it for proof-term closure
+   - optionally `VernacAbort` as an error/aborted end marker, not as a successfully declared lemma
+
+5. Identify sections by maintaining a segment stack:
+
+   - push `EVernacBeginSection id` as a section segment;
+   - push interactive modules/module types too, so their `End` commands do not accidentally close sections;
+   - pop on `EVernacEndSegment id` and record the end index when the popped segment is a section.
+
+   This is necessary because `EVernacEndSegment` only carries the name; it does not by itself say whether the `End` closes a section or a module.
+
+6. Keep the helpers pure with respect to Rocq execution: they should only inspect the current in-memory document and never advance/revert the cursor. Movement remains the responsibility of `Document.go_to`.
+
+7. If the JSON-RPC document-manager API should expose the same functionality, add read-only methods returning the spans above, plus optional movement methods that call `Document.go_to` on the selected index.
+
+## `rocq-ed` implementation plan
+
+1. Extend `bin/rocq-ed/request.ml` with request constructors:
+
+   ```ocaml
+   | GotoLemma : {name : string} -> (unit, int) t
+   | LemmaEnd : {name : string} -> (unit, int) t
+   | NextLemma : (unit, int) t
+   | GotoSection : {name : string} -> (unit, int) t
+   | SectionEnd : {name : string} -> (unit, int) t
+   | NextSectionOrEnd : {name : string} -> (unit, int) t
+   ```
+
+   The error payload should be the current cursor index, like `Goto`.
+
+2. Add request runners:
+
+   - find the target span using the new `Document` helper;
+   - choose `start_index` for `goto-lemma`, `next-lemma`, and `goto-section`;
+   - choose `end_index` for `lemma-end` and `section-end`;
+   - call `Document.go_to d ~index`;
+   - return clear errors for missing names, missing proof ends, missing section ends, or execution failures while advancing.
+
+3. In `bin/rocq-ed/main.ml`, add Cmdliner commands:
+
+   - `goto-lemma NAME FILE`
+   - `lemma-end NAME FILE`
+   - `next-lemma FILE`
+   - `goto-section NAME FILE`
+   - `section-end NAME FILE`
+
+   Existing `rocq_file` is positional argument 0, so named commands need a helper for `FILE` at positional argument 1 while `NAME` occupies positional argument 0.
+
+4. Register the new commands in the top-level command list and use `with_auto_print` for all movement commands.
+
+## Tests added
+
+Added cram tests in:
+
+- `fmdeps/rocq-agent-toolkit/rocq-doc-manager/tests/rocq-ed/named-navigation.t`
+
+The tests specify:
+
+- nested `goto-section` / `section-end` behavior;
+- `goto-lemma` across `Lemma`, `Theorem`, `Remark`, `Corollary`, and `Fact` declarations;
+- `lemma-end` for multi-line and one-line proofs;
+- `next-lemma` search-forward behavior and skipping the current lemma.

--- a/rocq-doc-manager/bin/rocq-ed/main.ml
+++ b/rocq-doc-manager/bin/rocq-ed/main.ml
@@ -15,14 +15,16 @@ let non_dir_file_with_ext : string -> string Arg.conv = fun ext ->
   in
   Arg.conv (parse, Arg.conv_printer Arg.non_dir_file)
 
-let rocq_file =
+let rocq_file_at index =
   let doc =
     "Path to an existing Rocq source file. The source file is expected to be \
      managed by a dune project, so that appropriate CLI arguments can be \
      automatically obtained."
   in
   let v_file = non_dir_file_with_ext ".v" in
-  Arg.(required & pos 0 (some v_file) None & info [] ~docv:"FILE" ~doc)
+  Arg.(required & pos index (some v_file) None & info [] ~docv:"FILE" ~doc)
+
+let rocq_file = rocq_file_at 0
 
 let no_build_deps =
   let doc =
@@ -299,6 +301,72 @@ let goto_cmd =
   let term = Term.(map with_auto_print (const run $ goto_pos) $ rocq_file) in
   Cmd.(make (info "goto" ~version ~doc) term)
 
+let named_target =
+  let doc = "Specifies the target name." in
+  Arg.(required & pos 0 (some string) None & info [] ~docv:"NAME" ~doc)
+
+let named_rocq_file = rocq_file_at 1
+
+let run_named_navigation request rocq_file =
+  match Protocol.client_request rocq_file request with
+  | Ok(()) -> ()
+  | Error(s, i) -> panic "Error: %s.\nThe cursor is now at index %i." s i
+
+let goto_lemma_cmd =
+  let doc =
+    "Moves the cursor to the theorem-like declaration named $(docv), whether \
+     it was introduced with $(b,Lemma), $(b,Theorem), $(b,Fact), \
+     $(b,Remark), $(b,Property), $(b,Proposition), or $(b,Corollary)."
+  in
+  let run name rocq_file =
+    run_named_navigation Request.(GotoLemma({name})) rocq_file
+  in
+  let term = Term.(map with_auto_print (const run $ named_target) $ named_rocq_file) in
+  Cmd.(make (info "goto-lemma" ~version ~doc) term)
+
+let lemma_end_cmd =
+  let doc =
+    "Moves the cursor to the final command that belongs to the declaration \
+     or proof of the theorem-like declaration named $(docv)."
+  in
+  let run name rocq_file =
+    run_named_navigation Request.(LemmaEnd({name})) rocq_file
+  in
+  let term = Term.(map with_auto_print (const run $ named_target) $ named_rocq_file) in
+  Cmd.(make (info "lemma-end" ~version ~doc) term)
+
+let next_lemma_cmd =
+  let doc =
+    "Moves the cursor to the next theorem-like declaration after the current \
+     cursor position."
+  in
+  let run rocq_file =
+    run_named_navigation Request.NextLemma rocq_file
+  in
+  let term = Term.(map with_auto_print (const run) $ rocq_file) in
+  Cmd.(make (info "next-lemma" ~version ~doc) term)
+
+let goto_section_cmd =
+  let doc =
+    "Moves the cursor to the beginning of the section named $(docv)."
+  in
+  let run name rocq_file =
+    run_named_navigation Request.(GotoSection({name})) rocq_file
+  in
+  let term = Term.(map with_auto_print (const run $ named_target) $ named_rocq_file) in
+  Cmd.(make (info "goto-section" ~version ~doc) term)
+
+let section_end_cmd =
+  let doc =
+    "Moves the cursor to the matching $(b,End) command for the section named \
+     $(docv)."
+  in
+  let run name rocq_file =
+    run_named_navigation Request.(SectionEnd({name})) rocq_file
+  in
+  let term = Term.(map with_auto_print (const run $ named_target) $ named_rocq_file) in
+  Cmd.(make (info "section-end" ~version ~doc) term)
+
 let main_man = [
   `S Manpage.s_description;
   `P "$(b,rocq-ed) is a command-line editor for Rocq source files. It \
@@ -350,7 +418,8 @@ let main_man = [
 let _ =
   let cmds =
     [ init_cmd; stop_cmd; status_cmd; steps_cmd; insert_cmd; query_cmd;
-      delete_cmd; commit_cmd; goals_cmd; undo_cmd; goto_cmd ]
+      delete_cmd; commit_cmd; goals_cmd; undo_cmd; goto_cmd; goto_lemma_cmd;
+      lemma_end_cmd; next_lemma_cmd; goto_section_cmd; section_end_cmd ]
   in
   let default = Term.(ret (const (`Help(`Pager, None)))) in
   let default_info =

--- a/rocq-doc-manager/bin/rocq-ed/main.ml
+++ b/rocq-doc-manager/bin/rocq-ed/main.ml
@@ -367,6 +367,17 @@ let section_end_cmd =
   let term = Term.(map with_auto_print (const run $ named_target) $ named_rocq_file) in
   Cmd.(make (info "section-end" ~version ~doc) term)
 
+let next_section_cmd =
+  let doc =
+    "Moves the cursor to the next section declaration after the current \
+     cursor position."
+  in
+  let run rocq_file =
+    run_named_navigation Request.NextSection rocq_file
+  in
+  let term = Term.(map with_auto_print (const run) $ rocq_file) in
+  Cmd.(make (info "next-section" ~version ~doc) term)
+
 let main_man = [
   `S Manpage.s_description;
   `P "$(b,rocq-ed) is a command-line editor for Rocq source files. It \
@@ -419,7 +430,8 @@ let _ =
   let cmds =
     [ init_cmd; stop_cmd; status_cmd; steps_cmd; insert_cmd; query_cmd;
       delete_cmd; commit_cmd; goals_cmd; undo_cmd; goto_cmd; goto_lemma_cmd;
-      lemma_end_cmd; next_lemma_cmd; goto_section_cmd; section_end_cmd ]
+      lemma_end_cmd; next_lemma_cmd; goto_section_cmd; section_end_cmd;
+      next_section_cmd ]
   in
   let default = Term.(ret (const (`Help(`Pager, None)))) in
   let default_info =

--- a/rocq-doc-manager/bin/rocq-ed/main.ml
+++ b/rocq-doc-manager/bin/rocq-ed/main.ml
@@ -378,6 +378,17 @@ let next_section_cmd =
   let term = Term.(map with_auto_print (const run) $ rocq_file) in
   Cmd.(make (info "next-section" ~version ~doc) term)
 
+let next_section_or_end_cmd =
+  let doc =
+    "Moves the cursor to the next section declaration, or to the matching \
+     $(b,End) command for the section named $(docv), whichever comes first."
+  in
+  let run name rocq_file =
+    run_named_navigation Request.(NextSectionOrEnd({name})) rocq_file
+  in
+  let term = Term.(map with_auto_print (const run $ named_target) $ named_rocq_file) in
+  Cmd.(make (info "next-section-or-end" ~version ~doc) term)
+
 let main_man = [
   `S Manpage.s_description;
   `P "$(b,rocq-ed) is a command-line editor for Rocq source files. It \
@@ -431,7 +442,7 @@ let _ =
     [ init_cmd; stop_cmd; status_cmd; steps_cmd; insert_cmd; query_cmd;
       delete_cmd; commit_cmd; goals_cmd; undo_cmd; goto_cmd; goto_lemma_cmd;
       lemma_end_cmd; next_lemma_cmd; goto_section_cmd; section_end_cmd;
-      next_section_cmd ]
+      next_section_cmd; next_section_or_end_cmd ]
   in
   let default = Term.(ret (const (`Help(`Pager, None)))) in
   let default_info =

--- a/rocq-doc-manager/bin/rocq-ed/request.ml
+++ b/rocq-doc-manager/bin/rocq-ed/request.ml
@@ -19,6 +19,7 @@ type (_, _) t =
   | GotoSection : {name : string} -> (unit, int) t
   | SectionEnd : {name : string} -> (unit, int) t
   | NextSection : (unit, int) t
+  | NextSectionOrEnd : {name : string} -> (unit, int) t
 
 let is_stop : type a b. (a, b) t -> bool = fun r ->
   match r with Stop -> true | _ -> false
@@ -61,6 +62,8 @@ let pp : type a b. (a, b) t Format.pp = fun ff r ->
       Format.fprintf ff "SectionEnd({name = %S})" name
   | NextSection ->
       Format.fprintf ff "NextSection"
+  | NextSectionOrEnd({name}) ->
+      Format.fprintf ff "NextSectionOrEnd({name = %S})" name
 
 let lines : string -> string array = fun s ->
   let lines = Dynarray.create () in
@@ -376,6 +379,35 @@ let run_next_section d =
   | None -> Error("no next section", Document.cursor_index d)
   | Some(span) -> run_go_to_index d ~index:span.Document.start_index
 
+let run_next_section_or_end d ~name =
+  let cur = Document.cursor_index d in
+  let next_section_index =
+    Option.map (fun span -> span.Document.start_index)
+      (Document.find_next_section d)
+  in
+  let section_end_index =
+    match Document.find_section d ~name with
+    | None ->
+        Error(Printf.sprintf "no section named %S" name, cur)
+    | Some({Document.end_index = None; _}) ->
+        Error(Printf.sprintf "no end found for section %S" name, cur)
+    | Some({Document.end_index = Some(index); _}) ->
+        Ok(if index > cur then Some(index) else None)
+  in
+  match section_end_index with
+  | Error(e) -> Error(e)
+  | Ok(section_end_index) ->
+  let earlier a b =
+    match (a, b) with
+    | (None, None) -> None
+    | (Some(i), None) | (None, Some(i)) -> Some(i)
+    | (Some(i), Some(j)) -> Some(min i j)
+  in
+  match earlier next_section_index section_end_index with
+  | None ->
+      Error(Printf.sprintf "no next section or end for section %S" name, cur)
+  | Some(index) -> run_go_to_index d ~index
+
 let run : type a b. Document.t -> (a, b) t ->
     (a, string * b) Result.t = fun d r ->
   match r with
@@ -395,3 +427,4 @@ let run : type a b. Document.t -> (a, b) t ->
   | GotoSection({name})   -> run_goto_section d ~name
   | SectionEnd({name})    -> run_section_end d ~name
   | NextSection           -> run_next_section d
+  | NextSectionOrEnd({name}) -> run_next_section_or_end d ~name

--- a/rocq-doc-manager/bin/rocq-ed/request.ml
+++ b/rocq-doc-manager/bin/rocq-ed/request.ml
@@ -18,6 +18,7 @@ type (_, _) t =
   | NextLemma : (unit, int) t
   | GotoSection : {name : string} -> (unit, int) t
   | SectionEnd : {name : string} -> (unit, int) t
+  | NextSection : (unit, int) t
 
 let is_stop : type a b. (a, b) t -> bool = fun r ->
   match r with Stop -> true | _ -> false
@@ -58,6 +59,8 @@ let pp : type a b. (a, b) t Format.pp = fun ff r ->
       Format.fprintf ff "GotoSection({name = %S})" name
   | SectionEnd({name}) ->
       Format.fprintf ff "SectionEnd({name = %S})" name
+  | NextSection ->
+      Format.fprintf ff "NextSection"
 
 let lines : string -> string array = fun s ->
   let lines = Dynarray.create () in
@@ -368,6 +371,11 @@ let run_section_end d ~name =
   | Some({Document.end_index = Some(index); _}) ->
       run_go_to_index d ~index
 
+let run_next_section d =
+  match Document.find_next_section d with
+  | None -> Error("no next section", Document.cursor_index d)
+  | Some(span) -> run_go_to_index d ~index:span.Document.start_index
+
 let run : type a b. Document.t -> (a, b) t ->
     (a, string * b) Result.t = fun d r ->
   match r with
@@ -386,3 +394,4 @@ let run : type a b. Document.t -> (a, b) t ->
   | NextLemma             -> run_next_lemma d
   | GotoSection({name})   -> run_goto_section d ~name
   | SectionEnd({name})    -> run_section_end d ~name
+  | NextSection           -> run_next_section d

--- a/rocq-doc-manager/bin/rocq-ed/request.ml
+++ b/rocq-doc-manager/bin/rocq-ed/request.ml
@@ -13,6 +13,11 @@ type (_, _) t =
   | Goals : (string, empty) t
   | Undo : {count : int} -> (unit, unit) t
   | Goto : {line: int; col: int option} -> (unit, int) t
+  | GotoLemma : {name : string} -> (unit, int) t
+  | LemmaEnd : {name : string} -> (unit, int) t
+  | NextLemma : (unit, int) t
+  | GotoSection : {name : string} -> (unit, int) t
+  | SectionEnd : {name : string} -> (unit, int) t
 
 let is_stop : type a b. (a, b) t -> bool = fun r ->
   match r with Stop -> true | _ -> false
@@ -43,6 +48,16 @@ let pp : type a b. (a, b) t Format.pp = fun ff r ->
       Format.fprintf ff "Goto({line = %i; col = None})" line
   | Goto({line; col = Some(col)}) ->
       Format.fprintf ff "Goto({line = %i; col = %i})" line col
+  | GotoLemma({name}) ->
+      Format.fprintf ff "GotoLemma({name = %S})" name
+  | LemmaEnd({name}) ->
+      Format.fprintf ff "LemmaEnd({name = %S})" name
+  | NextLemma ->
+      Format.fprintf ff "NextLemma"
+  | GotoSection({name}) ->
+      Format.fprintf ff "GotoSection({name = %S})" name
+  | SectionEnd({name}) ->
+      Format.fprintf ff "SectionEnd({name = %S})" name
 
 let lines : string -> string array = fun s ->
   let lines = Dynarray.create () in
@@ -310,16 +325,64 @@ let run_goto d ~line ~col =
   | Ok(()) -> Ok(())
   | Error(msg, _) -> Error(msg, Document.cursor_index d)
 
+let run_go_to_index d ~index =
+  match Document.go_to d ~index with
+  | Ok(()) -> Ok(())
+  | Error(msg, _) -> Error(msg, Document.cursor_index d)
+  | exception Invalid_argument(msg) -> Error(msg, Document.cursor_index d)
+
+let run_goto_lemma d ~name =
+  match Document.find_lemma d ~name with
+  | None ->
+      Error(Printf.sprintf "no lemma named %S" name, Document.cursor_index d)
+  | Some(span) -> run_go_to_index d ~index:span.Document.start_index
+
+let run_lemma_end d ~name =
+  match Document.find_lemma d ~name with
+  | None ->
+      Error(Printf.sprintf "no lemma named %S" name, Document.cursor_index d)
+  | Some({Document.end_index = None; _}) ->
+      Error(Printf.sprintf "no end found for lemma %S" name,
+        Document.cursor_index d)
+  | Some({Document.end_index = Some(index); _}) ->
+      run_go_to_index d ~index
+
+let run_next_lemma d =
+  match Document.find_next_lemma d with
+  | None -> Error("no next lemma", Document.cursor_index d)
+  | Some(span) -> run_go_to_index d ~index:span.Document.start_index
+
+let run_goto_section d ~name =
+  match Document.find_section d ~name with
+  | None ->
+      Error(Printf.sprintf "no section named %S" name, Document.cursor_index d)
+  | Some(span) -> run_go_to_index d ~index:span.Document.start_index
+
+let run_section_end d ~name =
+  match Document.find_section d ~name with
+  | None ->
+      Error(Printf.sprintf "no section named %S" name, Document.cursor_index d)
+  | Some({Document.end_index = None; _}) ->
+      Error(Printf.sprintf "no end found for section %S" name,
+        Document.cursor_index d)
+  | Some({Document.end_index = Some(index); _}) ->
+      run_go_to_index d ~index
+
 let run : type a b. Document.t -> (a, b) t ->
     (a, string * b) Result.t = fun d r ->
   match r with
-  | Stop              -> Ok(())
-  | Status({context}) -> run_status d ~context
-  | Steps({count})    -> run_steps d ~count
-  | Insert({text})    -> run_insert d ~text
-  | Query({text})     -> run_query d ~text
-  | Delete({count})   -> run_delete d ~count
-  | Commit            -> run_commit d
-  | Goals             -> run_goals d
-  | Undo({count})     -> run_undo d ~count
-  | Goto({line; col}) -> run_goto d ~line ~col
+  | Stop                  -> Ok(())
+  | Status({context})     -> run_status d ~context
+  | Steps({count})        -> run_steps d ~count
+  | Insert({text})        -> run_insert d ~text
+  | Query({text})         -> run_query d ~text
+  | Delete({count})       -> run_delete d ~count
+  | Commit                -> run_commit d
+  | Goals                 -> run_goals d
+  | Undo({count})         -> run_undo d ~count
+  | Goto({line; col})     -> run_goto d ~line ~col
+  | GotoLemma({name})     -> run_goto_lemma d ~name
+  | LemmaEnd({name})      -> run_lemma_end d ~name
+  | NextLemma             -> run_next_lemma d
+  | GotoSection({name})   -> run_goto_section d ~name
+  | SectionEnd({name})    -> run_section_end d ~name

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -577,6 +577,11 @@ let find_section : t -> name:string -> section_span option = fun d ~name ->
   let matches (span : section_span) = String.equal name span.name in
   List.find_opt matches (section_spans d)
 
+let find_next_section : t -> section_span option = fun d ->
+  let cur = cursor_index d in
+  let after_cursor (span : section_span) = span.start_index > cur in
+  List.find_opt after_cursor (section_spans d)
+
 let rev_prefix : t -> processed_item list = fun d ->
   let _ = get_backend d in
   d.rev_prefix

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -364,6 +364,219 @@ let go_to : t -> index:int -> (unit, string * command_error option) result =
   | true  -> revert_before d ~index ~erase:false; Ok(())
   | false -> advance_to d ~index
 
+type lemma_kind =
+  [ `Theorem | `Lemma | `Fact | `Remark | `Property
+  | `Proposition | `Corollary ]
+
+type lemma_span = {
+  name : string;
+  names : string list;
+  kind : lemma_kind;
+  start_index : int;
+  end_index : int option;
+}
+
+type section_span = {
+  name : string;
+  start_index : int;
+  end_index : int option;
+}
+
+type indexed_item = {
+  nav_index : int;
+  nav_kind : item_kind;
+}
+
+let indexed_items : t -> indexed_item list = fun d ->
+  let prefix =
+    let to_indexed (p : processed_item) =
+      {nav_index = p.index; nav_kind = p.kind}
+    in
+    List.rev_map to_indexed d.rev_prefix
+  in
+  let suffix =
+    let cur = cursor_index d in
+    let to_indexed i (u : unprocessed_item) =
+      {nav_index = cur + i; nav_kind = u.kind}
+    in
+    List.mapi to_indexed d.suffix
+  in
+  prefix @ suffix
+
+let command_of_indexed_item : indexed_item -> vernac_data option = fun item ->
+  match item.nav_kind with
+  | `Command(c) -> Some(c)
+  | `Blanks | `Ghost(_) -> None
+
+let has_search_suppressing_control : Rocq_vernac_entry.control list -> bool =
+    fun controls ->
+  let suppressing = function
+    | Rocq_vernac_entry.ControlFail
+    | Rocq_vernac_entry.ControlSucceed -> true
+    | _ -> false
+  in
+  List.exists suppressing controls
+
+let lemma_kind_of_theorem_kind : Decls.theorem_kind -> lemma_kind = fun kind ->
+  let open Decls in
+  match kind with
+  | Theorem -> `Theorem
+  | Lemma -> `Lemma
+  | Fact -> `Fact
+  | Remark -> `Remark
+  | Property -> `Property
+  | Proposition -> `Proposition
+  | Corollary -> `Corollary
+
+let lemma_start_of_command : vernac_data -> (string * string list * lemma_kind) option =
+    fun c ->
+  let (controls, expr) = c.CAst.v in
+  if has_search_suppressing_control controls then None else
+  match expr with
+  | Vernacexpr.VernacSynPure(Vernacexpr.VernacStartTheoremProof(kind, proof_exprs)) ->
+      let get_name ((id, _), _) = Names.Id.to_string id.CAst.v in
+      let names = List.map get_name proof_exprs in
+      let name = match names with [] -> "" | name :: _ -> name in
+      Some(name, names, lemma_kind_of_theorem_kind kind)
+  | _ -> None
+
+let lemma_end_command : vernac_data -> bool = fun c ->
+  let (controls, expr) = c.CAst.v in
+  not (has_search_suppressing_control controls) &&
+  match expr with
+  | Vernacexpr.VernacSynPure(Vernacexpr.VernacEndProof(_))
+  | Vernacexpr.VernacSynPure(Vernacexpr.VernacExactProof(_))
+  | Vernacexpr.VernacSynPure(Vernacexpr.VernacAbort) -> true
+  | _ -> false
+
+let rec find_lemma_end : indexed_item list -> int option = fun items ->
+  match items with
+  | [] -> None
+  | item :: items ->
+  match command_of_indexed_item item with
+  | Some(c) when lemma_end_command c -> Some(item.nav_index)
+  | _ -> find_lemma_end items
+
+let lemma_spans : t -> lemma_span list = fun d ->
+  let _ = get_backend d in
+  let rec scan acc items =
+    match items with
+    | [] -> List.rev acc
+    | item :: items ->
+    match command_of_indexed_item item with
+    | None -> scan acc items
+    | Some(c) ->
+    match lemma_start_of_command c with
+    | None -> scan acc items
+    | Some(name, names, kind) ->
+        let span : lemma_span =
+          {name; names; kind; start_index = item.nav_index;
+           end_index = find_lemma_end items}
+        in
+        scan (span :: acc) items
+  in
+  scan [] (indexed_items d)
+
+let find_lemma : t -> name:string -> lemma_span option = fun d ~name ->
+  let matches (span : lemma_span) =
+    List.exists (String.equal name) span.names
+  in
+  List.find_opt matches (lemma_spans d)
+
+let find_next_lemma : t -> lemma_span option = fun d ->
+  let cur = cursor_index d in
+  let after_cursor (span : lemma_span) = span.start_index > cur in
+  List.find_opt after_cursor (lemma_spans d)
+
+type segment_kind = [`Section | `Module | `ModuleType]
+
+type open_segment = {
+  seg_kind : segment_kind;
+  seg_name : string;
+  seg_start : int;
+}
+
+let id_to_string : Names.lident -> string = fun id ->
+  Names.Id.to_string id.CAst.v
+
+let segment_start_of_command : vernac_data -> (segment_kind * string) option =
+    fun c ->
+  let (controls, expr) = c.CAst.v in
+  if has_search_suppressing_control controls then None else
+  match expr with
+  | Vernacexpr.VernacSynterp(Rocq_vernac_entry.EVernacBeginSection(id)) ->
+      Some(`Section, id_to_string id)
+  | Vernacexpr.VernacSynterp(Rocq_vernac_entry.EVernacDefineModule
+      {id; has_body = false}) ->
+      Some(`Module, id_to_string id)
+  | Vernacexpr.VernacSynterp(Rocq_vernac_entry.EVernacDeclareModuleType
+      {id; has_body = false}) ->
+      Some(`ModuleType, id_to_string id)
+  | _ -> None
+
+let segment_end_of_command : vernac_data -> string option = fun c ->
+  let (controls, expr) = c.CAst.v in
+  if has_search_suppressing_control controls then None else
+  match expr with
+  | Vernacexpr.VernacSynterp(Rocq_vernac_entry.EVernacEndSegment(id)) ->
+      Some(id_to_string id)
+  | _ -> None
+
+let section_spans : t -> section_span list = fun d ->
+  let _ = get_backend d in
+  let close_section end_index spans (seg : open_segment) =
+    match seg.seg_kind with
+    | `Section ->
+        let span : section_span =
+          {name = seg.seg_name; start_index = seg.seg_start;
+           end_index = Some(end_index)}
+        in
+        span :: spans
+    | `Module | `ModuleType -> spans
+  in
+  let add_open_section spans (seg : open_segment) =
+    match seg.seg_kind with
+    | `Section ->
+        let span : section_span =
+          {name = seg.seg_name; start_index = seg.seg_start; end_index = None}
+        in
+        span :: spans
+    | `Module | `ModuleType -> spans
+  in
+  let rec scan stack spans items =
+    match items with
+    | [] ->
+        let spans = List.fold_left add_open_section spans stack in
+        let compare_start (s1 : section_span) (s2 : section_span) =
+          compare s1.start_index s2.start_index
+        in
+        List.sort compare_start spans
+    | item :: items ->
+    match command_of_indexed_item item with
+    | None -> scan stack spans items
+    | Some(c) ->
+    match segment_start_of_command c with
+    | Some(seg_kind, seg_name) ->
+        let seg = {seg_kind; seg_name; seg_start = item.nav_index} in
+        scan (seg :: stack) spans items
+    | None ->
+    match segment_end_of_command c with
+    | None -> scan stack spans items
+    | Some(end_name) ->
+        let (stack, spans) =
+          match stack with
+          | seg :: stack when String.equal seg.seg_name end_name ->
+              (stack, close_section item.nav_index spans seg)
+          | _ -> (stack, spans)
+        in
+        scan stack spans items
+  in
+  scan [] [] (indexed_items d)
+
+let find_section : t -> name:string -> section_span option = fun d ~name ->
+  let matches (span : section_span) = String.equal name span.name in
+  List.find_opt matches (section_spans d)
+
 let rev_prefix : t -> processed_item list = fun d ->
   let _ = get_backend d in
   d.rev_prefix
@@ -386,7 +599,7 @@ let contents : ?include_ghost:bool -> ?include_suffix:bool -> t -> string =
     if not (is_ghost p.kind) || include_ghost then
       Buffer.add_string b (document_text p.kind p.text)
   in
-  let add_unprocessed u =
+  let add_unprocessed (u : unprocessed_item) =
     if not (is_ghost u.kind) || include_ghost then
       Buffer.add_string b (document_text u.kind u.text)
   in

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -207,6 +207,48 @@ val advance_to : t -> index:int
     index of the last item in the document's suffix. *)
 val go_to : t -> index:int -> (unit, string * command_error option) result
 
+(** Kinds of theorem-like declarations that can be targeted by semantic
+    navigation. *)
+type lemma_kind =
+  [ `Theorem | `Lemma | `Fact | `Remark | `Property
+  | `Proposition | `Corollary ]
+
+(** Span of a theorem-like declaration and its proof. [start_index] is the
+    declaration command index. [end_index], when present, is the final command
+    belonging to the proof, such as [Qed.], [Defined.], or [Admitted.]. *)
+type lemma_span = {
+  name : string;
+  names : string list;
+  kind : lemma_kind;
+  start_index : int;
+  end_index : int option;
+}
+
+(** Span of a section. [start_index] is the [Section] command index, and
+    [end_index], when present, is the matching [End] command index. *)
+type section_span = {
+  name : string;
+  start_index : int;
+  end_index : int option;
+}
+
+(** [lemma_spans d] returns all theorem-like declarations in document order. *)
+val lemma_spans : t -> lemma_span list
+
+(** [section_spans d] returns all sections in document order. *)
+val section_spans : t -> section_span list
+
+(** [find_lemma d ~name] finds the first theorem-like declaration whose list of
+    declared names contains [name]. *)
+val find_lemma : t -> name:string -> lemma_span option
+
+(** [find_next_lemma d] finds the first theorem-like declaration whose start
+    index is strictly after the current cursor index. *)
+val find_next_lemma : t -> lemma_span option
+
+(** [find_section d ~name] finds the first section named [name]. *)
+val find_section : t -> name:string -> section_span option
+
 (** Document item kind: blank characters, command, or ghost command. *)
 type item_kind = [`Blanks | `Command of vernac_data | `Ghost of vernac_data]
 

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -249,6 +249,10 @@ val find_next_lemma : t -> lemma_span option
 (** [find_section d ~name] finds the first section named [name]. *)
 val find_section : t -> name:string -> section_span option
 
+(** [find_next_section d] finds the first section whose start index is strictly
+    after the current cursor index. *)
+val find_next_section : t -> section_span option
+
 (** Document item kind: blank characters, command, or ghost command. *)
 type item_kind = [`Blanks | `Command of vernac_data | `Ghost of vernac_data]
 

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/dune
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/dune
@@ -1,0 +1,2 @@
+(rocq.theory
+ (name text))

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/dune-project
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.21)
+(using rocq 0.11)

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
@@ -186,4 +186,56 @@ lemma declaration, the current lemma is skipped.
   $ rocq-ed status -C 0 test.v
     17|     <CURSOR>Remark inside : True.
 
+`next-section` searches forward from the current cursor. When the cursor is at a
+`Section` keyword, the current section is skipped.
+
+  $ rocq-ed goto --pos 1:1 test.v
+     1| <CURSOR>(* Prelude. *)
+     2| 
+     3| Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+  
+  Not currently in a proof.
+  $ rocq-ed next-section test.v
+     1| (* Prelude. *)
+     2| 
+     3| <CURSOR>Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+  
+  Not currently in a proof.
+  $ rocq-ed status -C 0 test.v
+     3| <CURSOR>Section Outer.
+  $ rocq-ed next-section test.v
+    11|   Theorem second : n = n.
+    12|   Proof.
+    13|     reflexivity.
+    14|   Qed.
+    15| 
+    16|   <CURSOR>Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   End Inner.
+    20| 
+    21|   Corollary later : True.
+  
+  Not currently in a proof.
+  $ rocq-ed status -C 0 test.v
+    16|   <CURSOR>Section Inner.
+  $ rocq-ed section-end second test.v
+  Error: no section named "second".
+  The cursor is now at index 21.
+  [1]
+  $ rocq-ed next-section test.v
+  Error: no next section.
+  The cursor is now at index 21.
+  [1]
+  $ rocq-ed status -C 0 test.v
+    16|   <CURSOR>Section Inner.
+
   $ rocq-ed stop test.v

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
@@ -6,6 +6,16 @@
 `goto-section` moves to the `Section` command introducing the named section.
 
   $ rocq-ed goto-section Outer test.v
+     1| (* Prelude. *)
+     2| 
+     3| <CURSOR>Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
      3| <CURSOR>Section Outer.
 
@@ -13,9 +23,35 @@
 stopping at an inner section end.
 
   $ rocq-ed section-end Outer test.v
+    20| 
+    21|   Corollary later : True.
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+    25| <CURSOR>End Outer.
+    26| 
+    27| Fact after_section : True.
+    28| Proof.
+    29|   exact I.
+    30| Qed.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
     25| <CURSOR>End Outer.
   $ rocq-ed section-end Inner test.v
+    14|   Qed.
+    15| 
+    16|   Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   <CURSOR>End Inner.
+    20| 
+    21|   Corollary later : True.
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
     19|   <CURSOR>End Inner.
 
@@ -25,6 +61,19 @@ Named navigation can also jump backwards to an item whose index is already in
 the processed prefix.
 
   $ rocq-ed goto-lemma first test.v
+     1| (* Prelude. *)
+     2| 
+     3| Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   <CURSOR>Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+     9|   Qed.
+    10| 
+    11|   Theorem second : n = n.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
      6|   <CURSOR>Lemma first : True.
 
@@ -33,9 +82,33 @@ For a standard proof that command is `Qed.`; this also works when the proof is
 written on one line.
 
   $ rocq-ed lemma-end second test.v
+     9|   Qed.
+    10| 
+    11|   Theorem second : n = n.
+    12|   Proof.
+    13|     reflexivity.
+    14|   <CURSOR>Qed.
+    15| 
+    16|   Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   End Inner.
+  
   $ rocq-ed status -C 0 test.v
     14|   <CURSOR>Qed.
   $ rocq-ed lemma-end inside test.v
+    13|     reflexivity.
+    14|   Qed.
+    15| 
+    16|   Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. <CURSOR>Qed.
+    19|   End Inner.
+    20| 
+    21|   Corollary later : True.
+    22|   Proof.
+    23|     exact I.
+  
   $ rocq-ed status -C 0 test.v
     18|     Proof. exact I. <CURSOR>Qed.
 
@@ -43,14 +116,73 @@ written on one line.
 lemma declaration, the current lemma is skipped.
 
   $ rocq-ed goto --pos 1:1 test.v
+     1| <CURSOR>(* Prelude. *)
+     2| 
+     3| Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+  
+  Not currently in a proof.
   $ rocq-ed next-lemma test.v
+     1| (* Prelude. *)
+     2| 
+     3| Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   <CURSOR>Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+     9|   Qed.
+    10| 
+    11|   Theorem second : n = n.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
      6|   <CURSOR>Lemma first : True.
   $ rocq-ed next-lemma test.v
+     6|   Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+     9|   Qed.
+    10| 
+    11|   <CURSOR>Theorem second : n = n.
+    12|   Proof.
+    13|     reflexivity.
+    14|   Qed.
+    15| 
+    16|   Section Inner.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
     11|   <CURSOR>Theorem second : n = n.
   $ rocq-ed lemma-end second test.v
+     9|   Qed.
+    10| 
+    11|   Theorem second : n = n.
+    12|   Proof.
+    13|     reflexivity.
+    14|   <CURSOR>Qed.
+    15| 
+    16|   Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   End Inner.
+  
   $ rocq-ed next-lemma test.v
+    12|   Proof.
+    13|     reflexivity.
+    14|   Qed.
+    15| 
+    16|   Section Inner.
+    17|     <CURSOR>Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   End Inner.
+    20| 
+    21|   Corollary later : True.
+    22|   Proof.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
     17|     <CURSOR>Remark inside : True.
 

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
@@ -1,0 +1,75 @@
+  $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
+  $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
+  $ export DUNE_CACHE=disabled
+  $ export TERM=dumb
+
+  $ rocq-ed init test.v
+
+`goto-section` moves to the `Section` command introducing the named section.
+
+  $ rocq-ed goto-section Outer test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+     3| <CURSOR>Section Outer.
+
+`section-end` moves to the matching `End` command, using nesting to avoid
+stopping at an inner section end.
+
+  $ rocq-ed section-end Outer test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    25| <CURSOR>End Outer.
+  $ rocq-ed section-end Inner test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    19|   <CURSOR>End Inner.
+
+`goto-lemma` matches theorem-style declarations regardless of their keyword.
+
+  $ rocq-ed goto-lemma first test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+     6|   <CURSOR>Lemma first : True.
+  $ rocq-ed goto-lemma second test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    11|   <CURSOR>Theorem second : n = n.
+  $ rocq-ed goto-lemma inside test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    17|     <CURSOR>Remark inside : True.
+  $ rocq-ed goto-lemma later test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    21|   <CURSOR>Corollary later : True.
+  $ rocq-ed goto-lemma after_section test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    27| <CURSOR>Fact after_section : True.
+
+Named navigation can also jump backwards to an item whose index is already in
+the processed prefix.
+
+  $ rocq-ed goto-lemma first test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+     6|   <CURSOR>Lemma first : True.
+
+`lemma-end` moves to the final command belonging to the declaration/proof.
+For a standard proof that command is `Qed.`; this also works when the proof is
+written on one line.
+
+  $ rocq-ed lemma-end second test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    14|   <CURSOR>Qed.
+  $ rocq-ed lemma-end inside test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    18|     Proof. exact I. <CURSOR>Qed.
+
+`next-lemma` searches forward from the current cursor. When the cursor is at a
+lemma declaration, the current lemma is skipped.
+
+  $ rocq-ed goto --pos 1:1 test.v >/dev/null
+  $ rocq-ed next-lemma test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+     6|   <CURSOR>Lemma first : True.
+  $ rocq-ed next-lemma test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    11|   <CURSOR>Theorem second : n = n.
+  $ rocq-ed lemma-end second test.v >/dev/null
+  $ rocq-ed next-lemma test.v >/dev/null
+  $ rocq-ed status -C 0 test.v
+    17|     <CURSOR>Remark inside : True.
+
+  $ rocq-ed stop test.v

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
@@ -30,10 +30,10 @@ stopping at an inner section end.
     24|   Qed.
     25| <CURSOR>End Outer.
     26| 
-    27| Fact after_section : True.
-    28| Proof.
-    29|   exact I.
-    30| Qed.
+    27| Section next.
+    28|   Fact after_section : True.
+    29|   Proof.
+    30|     exact I.
   
   Not currently in a proof.
   $ rocq-ed status -C 0 test.v
@@ -209,8 +209,67 @@ lemma declaration, the current lemma is skipped.
      8|     exact I.
   
   Not currently in a proof.
+  $ rocq-ed next-section test.v
+    11|   Theorem second : n = n.
+    12|   Proof.
+    13|     reflexivity.
+    14|   Qed.
+    15| 
+    16|   <CURSOR>Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   End Inner.
+    20| 
+    21|   Corollary later : True.
+  
+  Not currently in a proof.
+  $ rocq-ed next-section test.v
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+    25| End Outer.
+    26| 
+    27| <CURSOR>Section next.
+    28|   Fact after_section : True.
+    29|   Proof.
+    30|     exact I.
+    31|   Qed.
+    32| End next.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
+    27| <CURSOR>Section next.
+  $ rocq-ed goto --pos 1:1 test.v
+     1| <CURSOR>(* Prelude. *)
+     2| 
+     3| Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+  
+  Not currently in a proof.
+  $ rocq-ed next-section test.v
+     1| (* Prelude. *)
+     2| 
      3| <CURSOR>Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+  
+  Not currently in a proof.
+  $ rocq-ed steps test.v
+     1| (* Prelude. *)
+     2| 
+     3| Section Outer.<CURSOR>
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+  
+  Not currently in a proof.
   $ rocq-ed next-section test.v
     11|   Theorem second : n = n.
     12|   Proof.
@@ -227,15 +286,36 @@ lemma declaration, the current lemma is skipped.
   Not currently in a proof.
   $ rocq-ed status -C 0 test.v
     16|   <CURSOR>Section Inner.
-  $ rocq-ed section-end second test.v
-  Error: no section named "second".
-  The cursor is now at index 21.
-  [1]
+
+  $ rocq-ed section-end Inner test.v
+    14|   Qed.
+    15| 
+    16|   Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   <CURSOR>End Inner.
+    20| 
+    21|   Corollary later : True.
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+  
+  Not currently in a proof.
   $ rocq-ed next-section test.v
-  Error: no next section.
-  The cursor is now at index 21.
-  [1]
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+    25| End Outer.
+    26| 
+    27| <CURSOR>Section next.
+    28|   Fact after_section : True.
+    29|   Proof.
+    30|     exact I.
+    31|   Qed.
+    32| End next.
+  
+  Not currently in a proof.
   $ rocq-ed status -C 0 test.v
-    16|   <CURSOR>Section Inner.
+    27| <CURSOR>Section next.
 
   $ rocq-ed stop test.v

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
@@ -1,48 +1,30 @@
   $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
   $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
   $ export DUNE_CACHE=disabled
-  $ export TERM=dumb
-
   $ rocq-ed init test.v
 
 `goto-section` moves to the `Section` command introducing the named section.
 
-  $ rocq-ed goto-section Outer test.v >/dev/null
+  $ rocq-ed goto-section Outer test.v
   $ rocq-ed status -C 0 test.v
      3| <CURSOR>Section Outer.
 
 `section-end` moves to the matching `End` command, using nesting to avoid
 stopping at an inner section end.
 
-  $ rocq-ed section-end Outer test.v >/dev/null
+  $ rocq-ed section-end Outer test.v
   $ rocq-ed status -C 0 test.v
     25| <CURSOR>End Outer.
-  $ rocq-ed section-end Inner test.v >/dev/null
+  $ rocq-ed section-end Inner test.v
   $ rocq-ed status -C 0 test.v
     19|   <CURSOR>End Inner.
 
 `goto-lemma` matches theorem-style declarations regardless of their keyword.
 
-  $ rocq-ed goto-lemma first test.v >/dev/null
-  $ rocq-ed status -C 0 test.v
-     6|   <CURSOR>Lemma first : True.
-  $ rocq-ed goto-lemma second test.v >/dev/null
-  $ rocq-ed status -C 0 test.v
-    11|   <CURSOR>Theorem second : n = n.
-  $ rocq-ed goto-lemma inside test.v >/dev/null
-  $ rocq-ed status -C 0 test.v
-    17|     <CURSOR>Remark inside : True.
-  $ rocq-ed goto-lemma later test.v >/dev/null
-  $ rocq-ed status -C 0 test.v
-    21|   <CURSOR>Corollary later : True.
-  $ rocq-ed goto-lemma after_section test.v >/dev/null
-  $ rocq-ed status -C 0 test.v
-    27| <CURSOR>Fact after_section : True.
-
 Named navigation can also jump backwards to an item whose index is already in
 the processed prefix.
 
-  $ rocq-ed goto-lemma first test.v >/dev/null
+  $ rocq-ed goto-lemma first test.v
   $ rocq-ed status -C 0 test.v
      6|   <CURSOR>Lemma first : True.
 
@@ -50,25 +32,25 @@ the processed prefix.
 For a standard proof that command is `Qed.`; this also works when the proof is
 written on one line.
 
-  $ rocq-ed lemma-end second test.v >/dev/null
+  $ rocq-ed lemma-end second test.v
   $ rocq-ed status -C 0 test.v
     14|   <CURSOR>Qed.
-  $ rocq-ed lemma-end inside test.v >/dev/null
+  $ rocq-ed lemma-end inside test.v
   $ rocq-ed status -C 0 test.v
     18|     Proof. exact I. <CURSOR>Qed.
 
 `next-lemma` searches forward from the current cursor. When the cursor is at a
 lemma declaration, the current lemma is skipped.
 
-  $ rocq-ed goto --pos 1:1 test.v >/dev/null
-  $ rocq-ed next-lemma test.v >/dev/null
+  $ rocq-ed goto --pos 1:1 test.v
+  $ rocq-ed next-lemma test.v
   $ rocq-ed status -C 0 test.v
      6|   <CURSOR>Lemma first : True.
-  $ rocq-ed next-lemma test.v >/dev/null
+  $ rocq-ed next-lemma test.v
   $ rocq-ed status -C 0 test.v
     11|   <CURSOR>Theorem second : n = n.
-  $ rocq-ed lemma-end second test.v >/dev/null
-  $ rocq-ed next-lemma test.v >/dev/null
+  $ rocq-ed lemma-end second test.v
+  $ rocq-ed next-lemma test.v
   $ rocq-ed status -C 0 test.v
     17|     <CURSOR>Remark inside : True.
 

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/run.t
@@ -318,4 +318,83 @@ lemma declaration, the current lemma is skipped.
   $ rocq-ed status -C 0 test.v
     27| <CURSOR>Section next.
 
+`next-section-or-end` searches forward to the next `Section` command, or to the
+matching `End` command for the named section, whichever comes first.
+
+  $ rocq-ed goto-section Outer test.v
+     1| (* Prelude. *)
+     2| 
+     3| <CURSOR>Section Outer.
+     4|   Variable n : nat.
+     5| 
+     6|   Lemma first : True.
+     7|   Proof.
+     8|     exact I.
+  
+  Not currently in a proof.
+  $ rocq-ed next-section-or-end Outer test.v
+    11|   Theorem second : n = n.
+    12|   Proof.
+    13|     reflexivity.
+    14|   Qed.
+    15| 
+    16|   <CURSOR>Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   End Inner.
+    20| 
+    21|   Corollary later : True.
+  
+  Not currently in a proof.
+  $ rocq-ed status -C 0 test.v
+    16|   <CURSOR>Section Inner.
+  $ rocq-ed next-section-or-end Inner test.v
+    14|   Qed.
+    15| 
+    16|   Section Inner.
+    17|     Remark inside : True.
+    18|     Proof. exact I. Qed.
+    19|   <CURSOR>End Inner.
+    20| 
+    21|   Corollary later : True.
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+  
+  Not currently in a proof.
+  $ rocq-ed status -C 0 test.v
+    19|   <CURSOR>End Inner.
+  $ rocq-ed next-section-or-end Outer test.v
+    20| 
+    21|   Corollary later : True.
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+    25| <CURSOR>End Outer.
+    26| 
+    27| Section next.
+    28|   Fact after_section : True.
+    29|   Proof.
+    30|     exact I.
+  
+  Not currently in a proof.
+  $ rocq-ed status -C 0 test.v
+    25| <CURSOR>End Outer.
+  $ rocq-ed next-section-or-end next test.v
+    22|   Proof.
+    23|     exact I.
+    24|   Qed.
+    25| End Outer.
+    26| 
+    27| <CURSOR>Section next.
+    28|   Fact after_section : True.
+    29|   Proof.
+    30|     exact I.
+    31|   Qed.
+    32| End next.
+  
+  Not currently in a proof.
+  $ rocq-ed status -C 0 test.v
+    27| <CURSOR>Section next.
+
   $ rocq-ed stop test.v

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/test.v
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/test.v
@@ -24,7 +24,9 @@ Section Outer.
   Qed.
 End Outer.
 
-Fact after_section : True.
-Proof.
-  exact I.
-Qed.
+Section next.
+  Fact after_section : True.
+  Proof.
+    exact I.
+  Qed.
+End next.

--- a/rocq-doc-manager/tests/rocq-ed/named-navigation.t/test.v
+++ b/rocq-doc-manager/tests/rocq-ed/named-navigation.t/test.v
@@ -1,0 +1,30 @@
+(* Prelude. *)
+
+Section Outer.
+  Variable n : nat.
+
+  Lemma first : True.
+  Proof.
+    exact I.
+  Qed.
+
+  Theorem second : n = n.
+  Proof.
+    reflexivity.
+  Qed.
+
+  Section Inner.
+    Remark inside : True.
+    Proof. exact I. Qed.
+  End Inner.
+
+  Corollary later : True.
+  Proof.
+    exact I.
+  Qed.
+End Outer.
+
+Fact after_section : True.
+Proof.
+  exact I.
+Qed.


### PR DESCRIPTION
The coding was done with heavy use of codex. The prompt and initial proposal are included.

The commands that were added enable:
- finding the end of a section;
- finding the end of a proof;
- finding sections and proofs by name. 

Missing are:
- similar commands for modules;
- considerations for the fact that certain declarations have multiple proofs.