### PR TITLE
feat(rocq-term-deps): expose term_deps as Ltac2 functions

### DIFF
--- a/rocq-term-deps/dune-project
+++ b/rocq-term-deps/dune-project
@@ -12,6 +12,7 @@
  (name rocq-term-deps)
  (synopsis "Rocq plugin for computing the dependencies of a constant")
  (depends
-  rocq-core))
+  rocq-core
+  rocq-stdlib))
 
 (subst disabled)

--- a/rocq-term-deps/plugin/dune
+++ b/rocq-term-deps/plugin/dune
@@ -3,6 +3,7 @@
  (public_name rocq-term-deps.plugin)
  (libraries
   rocq-runtime.vernac
+  rocq-runtime.plugins.ltac2
   yojson))
 
 (rocq.pp (modules g_term_deps))

--- a/rocq-term-deps/plugin/term_deps.ml
+++ b/rocq-term-deps/plugin/term_deps.ml
@@ -1,17 +1,23 @@
-type t = Names.Cset.t * Names.Mindset.t
+(* We track mutual inductives in a [Mindmap_env] used as a set (the [_env]
+   variant; [Names.Mindset] is deprecated). *)
+type t = Names.Cset.t * unit Names.Mindmap_env.t
+
+(* The mutual-inductive names collected in [inds], as a list. *)
+let minds_of (inds : unit Names.Mindmap_env.t) : Names.MutInd.t list =
+  List.rev (Names.Mindmap_env.fold (fun k _ acc -> k :: acc) inds [])
 
 let term_deps : Constr.named_context -> Constr.t -> t = fun hyps t ->
   let constants = ref Names.Cset.empty in
-  let inductives = ref Names.Mindset.empty in
+  let inductives = ref Names.Mindmap_env.empty in
   let rec term_deps t =
     let _ =
       match Constr.kind t with
       | Constr.Const((c,_))     ->
           constants := Names.Cset.add c !constants
       | Constr.Ind((i,_))       ->
-          inductives := Names.Mindset.add (fst i) !inductives
+          inductives := Names.Mindmap_env.add (fst i) () !inductives
       | Constr.Construct((c,_)) ->
-          inductives := Names.Mindset.add (fst (fst c)) !inductives
+          inductives := Names.Mindmap_env.add (fst (fst c)) () !inductives
       | _                       ->
           ()
     in
@@ -20,6 +26,12 @@ let term_deps : Constr.named_context -> Constr.t -> t = fun hyps t ->
   List.iter (Context.Named.Declaration.iter_constr term_deps) hyps;
   term_deps t;
   (!constants, !inductives)
+
+(* The (inductive names, constant names) of a collected [t]. Shared by the
+   [DepsOfJSON] command and the [term_deps] Ltac2 external. *)
+let dep_names ((constants, inductives) : t) : string list * string list =
+  (List.map Names.MutInd.to_string (minds_of inductives),
+   List.map Names.Constant.to_string (Names.Cset.elements constants))
 
 let constant_of_qualid : Libnames.qualid -> Names.Constant.t = fun r ->
   let error pp = CErrors.user_err ?loc:r.CAst.loc pp in
@@ -52,7 +64,7 @@ let print_term_deps : Libnames.qualid -> unit = fun r ->
   in
   let (constants, inductives) = term_deps hyps t in
   let constants = Names.Cset.elements constants in
-  let inductives = Names.Mindset.elements inductives in
+  let inductives = minds_of inductives in
   let pp_c c = Pp.(str "- " ++ Names.Constant.print c ++ fnl ()) in
   let pp_i i = Pp.(str "- " ++ Names.MutInd.print i ++ fnl ()) in
   let pp =
@@ -80,14 +92,27 @@ let print_json_term_deps : Libnames.qualid -> unit = fun r ->
     match def with
     | None      -> []
     | Some(def) ->
-    let (constants, inductives) = term_deps hyps def in
-    let constants = Names.Cset.elements constants in
-    let inductives = Names.Mindset.elements inductives in
-    let make_ind i = `String(Names.MutInd.to_string i) in
-    let make_cst c = `String(Names.Constant.to_string c) in
-    ("inductive_deps", `List(List.map make_ind inductives)) ::
-    ("constant_deps" , `List(List.map make_cst constants) ) :: []
+    let (ind_names, cst_names) = dep_names (term_deps hyps def) in
+    let str s = `String(s) in
+    ("inductive_deps", `List(List.map str ind_names)) ::
+    ("constant_deps" , `List(List.map str cst_names)) :: []
   in
   let json : Yojson.Safe.t = `Assoc(fields) in
   let data = Yojson.Safe.pretty_to_string ~std:true json in
   Feedback.msg_notice (Pp.str data)
+
+(* Ltac2 external: [term_deps : constr -> string list * string list] returns the
+   immediate (inductive names, constant names) dependencies of a single term.
+   This lets Ltac2 code compute the dependencies of an arbitrary term (e.g. a
+   sub-term of a goal/spec), not just a defined constant. The result is returned
+   as plain structured data, so callers can post-process it freely (e.g. build a
+   JSON object, union over several terms, or look the names back up). *)
+let () =
+  let open Ltac2_plugin in
+  let open Tac2ffi in
+  let open Tac2externals in
+  let define s =
+    define Tac2expr.{ mltac_plugin = "rocq-term-deps"; mltac_tactic = s }
+  in
+  define "term_deps" (constr @-> ret (pair (list string) (list string))) (fun t ->
+    dep_names (term_deps [] (EConstr.Unsafe.to_constr t)))

--- a/rocq-term-deps/rocq-term-deps.opam
+++ b/rocq-term-deps/rocq-term-deps.opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/SkylabsAI/skylabs-fm/issues"
 depends: [
   "dune" {>= "3.21"}
   "rocq-core"
+  "rocq-stdlib"
   "odoc" {with-doc}
 ]
 build: [

--- a/rocq-term-deps/tests/ltac2.t
+++ b/rocq-term-deps/tests/ltac2.t
@@ -1,0 +1,39 @@
+The [term_deps] Ltac2 external computes the immediate (syntactic) inductive and
+constant dependencies of an arbitrary term — not just a defined constant — and
+returns them as plain structured data (string lists).
+
+  $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
+  $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
+  $ export DUNE_CACHE=disabled
+  $ cat > test.v <<EOF
+  > Require Import skylabs_ai.tools.term_deps.TermDeps.
+  > From Ltac2 Require Import Ltac2.
+  > Ltac2 show (t : constr) : unit :=
+  >   let (inds, consts) := term_deps t in
+  >   Message.print (Message.of_string (String.concat ""
+  >     ["inductives: "; String.concat ", " inds;
+  >      " | constants: "; String.concat ", " consts])).
+  > (* a single closed term *)
+  > Ltac2 Eval show constr:(1 + 2 * 3).
+  > (* a term with a bound variable (the Rel is ignored) *)
+  > Ltac2 Eval show constr:(fun n : nat => n + 0).
+  > (* immediate, NOT transitive: [foo] is reported, its body is not unfolded
+  >    (so [Nat.add], used only inside [foo], does not appear) *)
+  > Definition foo (n : nat) := n + 2.
+  > Ltac2 Eval show constr:(foo 3).
+  > (* a free (section) variable is ignored; the surrounding constants are kept *)
+  > Section S.
+  >   Variable y : nat.
+  >   Ltac2 Eval show constr:(y + foo y).
+  > End S.
+  > EOF
+
+  $ rocq compile test.v
+  inductives: Corelib.Init.Datatypes.nat | constants: Corelib.Init.Nat.mul, Corelib.Init.Nat.add
+  - : unit = ()
+  inductives: Corelib.Init.Datatypes.nat | constants: Corelib.Init.Nat.add
+  - : unit = ()
+  inductives: Corelib.Init.Datatypes.nat | constants: test.foo
+  - : unit = ()
+  inductives:  | constants: Corelib.Init.Nat.add, test.foo
+  - : unit = ()

--- a/rocq-term-deps/theories/TermDeps.v
+++ b/rocq-term-deps/theories/TermDeps.v
@@ -1,0 +1,16 @@
+(** Ltac2 surface of the [rocq-term-deps] plugin. *)
+Require Export skylabs_ai.tools.term_deps.plugin.
+From Ltac2 Require Import Ltac2.
+
+(** [term_deps t] returns the *immediate* dependencies of the single term [t] as
+    a pair [(inductive_names, constant_names)] of absolute-name strings.
+
+    Notes:
+    - Dependencies are *syntactic / immediate*: a constant occurring in [t] is
+      reported as-is; its body is NOT unfolded (so this is not transitive).
+    - [Var], [Rel] and [Evar] nodes are ignored, so it is safe on open terms.
+    - The result is plain structured data: callers can union it over several
+      terms, build a JSON object (e.g. with [ltac2-json]), or resolve the names
+      back to references with [Ltac2.Env.get] / [Env.expand]. *)
+Ltac2 @ external term_deps : constr -> string list * string list :=
+  "rocq-term-deps" "term_deps".

--- a/rocq-term-deps/theories/dune
+++ b/rocq-term-deps/theories/dune
@@ -2,4 +2,5 @@
  (name skylabs_ai.tools.term_deps)
  (package rocq-term-deps)
  (generate_project_file)
- (plugins rocq-term-deps.plugin))
+ (plugins rocq-term-deps.plugin)
+ (theories Ltac2))


### PR DESCRIPTION
- add `term_deps` as an Ltac2 function that other libraries can use (**note:** same as `DepsOf`, but terms can be used directly)
- remove deprecation warning for `Mindset` by moving to `Mindmap_env`