### PR TITLE
rocq-doc-manager: add a structured_goals query

### DIFF
--- a/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
+++ b/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
@@ -131,10 +131,11 @@ let structured_goal_of_evar : Evd.evar_map -> Evar.t -> structured_goal =
   {hyps; goal = pr (Evd.evar_concl evi)}
 
 let structured_goals state =
-  match state.Vernac.State.proof with None -> (state, Ok(None))
-  | Some(proof) ->
+  let get_goals proof =
     let Proof.{goals; sigma; _} = Proof.data proof in
-    (state, Ok(Some(List.map (structured_goal_of_evar sigma) goals)))
+    List.map (structured_goal_of_evar sigma) goals
+  in
+  (state, Ok(Option.map get_goals state.Vernac.State.proof))
 
 let run state off text =
   Feed.reset ();

--- a/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
+++ b/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
@@ -116,6 +116,26 @@ let fixup_subgoal : Pp.t -> Pp.t = fun p ->
     | _ -> raise Fallback
   with Fallback -> p
 
+let structured_goal_of_evar : Evd.evar_map -> Evar.t -> structured_goal =
+    fun sigma ev ->
+  let evi = Evd.find_undefined sigma ev in
+  let env = Evd.evar_filtered_env (Global.env ()) evi in
+  let pr c = Pp.string_of_ppcmds (Printer.pr_econstr_env env sigma c) in
+  let open Context.Named.Declaration in
+  let hyp_of_decl d =
+    let name = Names.Id.to_string (get_id d) in
+    let def = Option.map pr (get_value d) in
+    {name; def; hyp_type = pr (get_type d)}
+  in
+  let hyps = List.rev_map hyp_of_decl (Evd.evar_filtered_context evi) in
+  {hyps; goal = pr (Evd.evar_concl evi)}
+
+let structured_goals state =
+  match state.Vernac.State.proof with None -> (state, Ok(None))
+  | Some(proof) ->
+    let Proof.{goals; sigma; _} = Proof.data proof in
+    (state, Ok(Some(List.map (structured_goal_of_evar sigma) goals)))
+
 let run state off text =
   Feed.reset ();
   try
@@ -213,6 +233,7 @@ let run_command : type r e. state -> (r, e) command -> state * (r, e) result =
   | Run({off; text})          -> run state off text
   | BackTo({sid})             -> back_to state sid
   | Fork({pipe_in; pipe_out}) -> fork state ~pipe_in ~pipe_out
+  | StructuredGoals           -> structured_goals state
 
 let interact : state -> unit = fun state ->
   let pid = Unix.getpid () in

--- a/ocaml-rocq-simple-api/lib/api/rocq_toplevel.ml
+++ b/ocaml-rocq-simple-api/lib/api/rocq_toplevel.ml
@@ -83,9 +83,8 @@ let run : toplevel -> off:int -> text:string ->
     (run_data, string * run_error) result = fun s ~off ~text ->
   request s (Run({off; text}))
 
-let structured_goals : toplevel ->
-    (structured_goal list option, string) result = fun s ->
-  request s StructuredGoals
+let structured_goals : toplevel -> structured_goal list option = fun s ->
+  match request s StructuredGoals with Ok(goals) -> goals
 
 let unlink file =
   try Unix.unlink file with Unix.Unix_error(_,_,_) -> ()

--- a/ocaml-rocq-simple-api/lib/api/rocq_toplevel.ml
+++ b/ocaml-rocq-simple-api/lib/api/rocq_toplevel.ml
@@ -83,6 +83,10 @@ let run : toplevel -> off:int -> text:string ->
     (run_data, string * run_error) result = fun s ~off ~text ->
   request s (Run({off; text}))
 
+let structured_goals : toplevel ->
+    (structured_goal list option, string) result = fun s ->
+  request s StructuredGoals
+
 let unlink file =
   try Unix.unlink file with Unix.Unix_error(_,_,_) -> ()
 

--- a/ocaml-rocq-simple-api/lib/api/rocq_toplevel.mli
+++ b/ocaml-rocq-simple-api/lib/api/rocq_toplevel.mli
@@ -79,6 +79,17 @@ type globrefs_diff = {
   removed_inductives : Names.MutInd.t list;
 }
 
+type structured_hyp = {
+  name : string;
+  def : string option;
+  hyp_type : string;
+}
+
+type structured_goal = {
+  hyps : structured_hyp list;
+  goal : string;
+}
+
 type proof_state = {
   given_up_goals : int;
   shelved_goals : int;
@@ -107,11 +118,20 @@ type run_error = {
 val run : toplevel -> off:int -> text:string
   -> (run_data, string * run_error) result
 
+(** [structured_goals t] returns the the focused goals at the cursor, or [None]
+    when [t] is not in proof mode. It does not change the state. *)
+val structured_goals : toplevel
+  -> (structured_goal list option, string) result
+
 (** {2 JSON serialization for data returned by [run]} *)
 
 val feedback_message_to_yojson : feedback_message -> Yojson.Safe.t
 
 val globrefs_diff_to_yojson : globrefs_diff -> Yojson.Safe.t
+
+val structured_hyp_to_yojson : structured_hyp -> Yojson.Safe.t
+
+val structured_goal_to_yojson : structured_goal -> Yojson.Safe.t
 
 val proof_state_to_yojson : proof_state -> Yojson.Safe.t
 

--- a/ocaml-rocq-simple-api/lib/api/rocq_toplevel.mli
+++ b/ocaml-rocq-simple-api/lib/api/rocq_toplevel.mli
@@ -118,10 +118,9 @@ type run_error = {
 val run : toplevel -> off:int -> text:string
   -> (run_data, string * run_error) result
 
-(** [structured_goals t] returns the the focused goals at the cursor, or [None]
-    when [t] is not in proof mode. It does not change the state. *)
-val structured_goals : toplevel
-  -> (structured_goal list option, string) result
+(** [structured_goals t] returns the focused goals at the cursor, or [None] if
+    [t] is not in proof mode. It does not change the state. *)
+val structured_goals : toplevel -> structured_goal list option
 
 (** {2 JSON serialization for data returned by [run]} *)
 

--- a/ocaml-rocq-simple-api/lib/internal/rocq_toplevel_data.ml
+++ b/ocaml-rocq-simple-api/lib/internal/rocq_toplevel_data.ml
@@ -81,8 +81,10 @@ type run_error = {
 }
 [@@deriving to_yojson]
 
+type empty = |
+
 type (_, _) command =
   | Run : {off : int; text : string} -> (run_data, string * run_error) command
   | BackTo : {sid : int} -> (unit, string) command
   | Fork : {pipe_in : string; pipe_out : string} -> (int, string) command
-  | StructuredGoals : (structured_goal list option, string) command
+  | StructuredGoals : (structured_goal list option, empty) command

--- a/ocaml-rocq-simple-api/lib/internal/rocq_toplevel_data.ml
+++ b/ocaml-rocq-simple-api/lib/internal/rocq_toplevel_data.ml
@@ -46,6 +46,19 @@ let empty_globrefs_diff = {
   removed_inductives = [];
 }
 
+type structured_hyp = {
+  name : string;
+  def : (string option [@default None]);
+  hyp_type : string [@key "type"];
+}
+[@@deriving to_yojson]
+
+type structured_goal = {
+  hyps : structured_hyp list;
+  goal : string;
+}
+[@@deriving to_yojson]
+
 type proof_state = {
   given_up_goals : (int [@default 0]);
   shelved_goals : (int [@default 0]);
@@ -72,3 +85,4 @@ type (_, _) command =
   | Run : {off : int; text : string} -> (run_data, string * run_error) command
   | BackTo : {sid : int} -> (unit, string) command
   | Fork : {pipe_in : string; pipe_out : string} -> (int, string) command
+  | StructuredGoals : (structured_goal list option, string) command

--- a/rocq-doc-manager/README.md
+++ b/rocq-doc-manager/README.md
@@ -93,6 +93,19 @@ API Objects
 - Field `removed_constants`: a list where each element is a string.
 - Field `added_constants`: a list where each element is a string.
 
+### `StructuredHyp`
+
+- Description: Hypothesis of a structured goal.
+- Field `type`: a string.
+- Field `defn`: either `null` or a string.
+- Field `name`: a string.
+
+### `StructuredGoal`
+
+- Description: Structured goal.
+- Field `goal`: a string.
+- Field `hyps`: a list where each element is an instance of the `StructuredHyp` object.
+
 ### `ProofState`
 
 - Description: Summary of a Rocq proof state, including the text of focused goals.
@@ -396,6 +409,14 @@ API Methods
 - Response payload: a list where each element is an instance of the `Sentence` object.
 - Error payload: an instance of the `SentenceSplitError` object.
 - Failure mode: recoverable failure.
+
+### `structured_goals`
+
+- Description: returns the focused goals at the cursor, or `null` when not in proof mode; does not change the state.
+- Arguments (in order, or named):
+  - `cursor`: the cursor to perform the operation on (as an integer).
+- Response payload: either `null` or a list where each element is an instance of the `StructuredGoal` object.
+- Failure mode: never fails.
 
 ### `whitespace_required`
 

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -435,6 +435,32 @@ let globrefs_diff =
   API.declare_object api ~name:"GlobrefsDiff" ~descr:"environment \
     modification performed by a Rocq command" ~default ~encode ~decode fields
 
+let structured_hyp =
+  let fields =
+    API.Fields.add ~name:"name" S.string @@
+    API.Fields.add ~name:"def" S.(nullable string) @@
+    API.Fields.add ~name:"type" S.string @@
+    API.Fields.nil
+  in
+  let open Rocq_toplevel in
+  let encode (name, (def, (hyp_type, ()))) = {name; def; hyp_type} in
+  let decode {name; def; hyp_type} = (name, (def, (hyp_type, ()))) in
+  API.declare_object api ~name:"StructuredHyp"
+    ~descr:"Hypothesis of a structured goal"
+    ~encode ~decode fields
+
+let structured_goal =
+  let fields =
+    API.Fields.add ~name:"hyps" S.(list (obj structured_hyp)) @@
+    API.Fields.add ~name:"goal" S.string @@
+    API.Fields.nil
+  in
+  let open Rocq_toplevel in
+  let encode (hyps, (goal, ())) = {hyps; goal} in
+  let decode {hyps; goal} = (hyps, (goal, ())) in
+  API.declare_object api ~name:"StructuredGoal" ~descr:"Structured goal"
+    ~encode ~decode fields
+
 let proof_state =
   let fields =
     API.Fields.add ~name:"given_up_goals" S.int @@
@@ -749,6 +775,14 @@ let _ =
     ~ret:S.(list any) ~err:S.null
     @@ fun d (text, (indices, ())) ->
   let res = Document.query_json_all d ~text ?indices in
+  Result.map_error (fun s -> (s, ())) res
+
+let _ =
+  declare_full ~name:"structured_goals" ~descr:"returns the focused goals at \
+      the cursor, or `null` when not in proof mode; does not change the state"
+    ~args:A.nil ~ret:S.(nullable (list (obj structured_goal))) ~err:S.null
+    @@ fun d () ->
+  let res = Document.structured_goals d in
   Result.map_error (fun s -> (s, ())) res
 
 let _ =

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -438,7 +438,7 @@ let globrefs_diff =
 let structured_hyp =
   let fields =
     API.Fields.add ~name:"name" S.string @@
-    API.Fields.add ~name:"def" S.(nullable string) @@
+    API.Fields.add ~name:"defn" S.(nullable string) @@
     API.Fields.add ~name:"type" S.string @@
     API.Fields.nil
   in
@@ -778,12 +778,11 @@ let _ =
   Result.map_error (fun s -> (s, ())) res
 
 let _ =
-  declare_full ~name:"structured_goals" ~descr:"returns the focused goals at \
-      the cursor, or `null` when not in proof mode; does not change the state"
-    ~args:A.nil ~ret:S.(nullable (list (obj structured_goal))) ~err:S.null
+  declare ~name:"structured_goals" ~descr:"returns the focused goals at the \
+      cursor, or `null` when not in proof mode; does not change the state"
+    ~args:A.nil ~ret:S.(nullable (list (obj structured_goal)))
     @@ fun d () ->
-  let res = Document.structured_goals d in
-  Result.map_error (fun s -> (s, ())) res
+  Document.structured_goals d
 
 let _ =
   declare_full ~name:"materialize" ~descr:"materializes the cursor, \

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -525,6 +525,11 @@ let query : t -> text:string -> (command_data, string) result = fun d ~text ->
   with_rollback d @@ fun _ ->
   Result.map_error fst (insert_command ~ghost:true d ~text)
 
+let structured_goals : t ->
+    (Rocq_toplevel.structured_goal list option, string) result = fun d ->
+  with_synced_backend d @@ fun backend ->
+  Rocq_toplevel.structured_goals backend.top
+
 let get_info_or_notice : command_data -> string list = fun data ->
   let filter Rocq_toplevel.{level; text; _} =
     match level with

--- a/rocq-doc-manager/lib/document.ml
+++ b/rocq-doc-manager/lib/document.ml
@@ -525,8 +525,8 @@ let query : t -> text:string -> (command_data, string) result = fun d ~text ->
   with_rollback d @@ fun _ ->
   Result.map_error fst (insert_command ~ghost:true d ~text)
 
-let structured_goals : t ->
-    (Rocq_toplevel.structured_goal list option, string) result = fun d ->
+let structured_goals : t -> Rocq_toplevel.structured_goal list option =
+    fun d ->
   with_synced_backend d @@ fun backend ->
   Rocq_toplevel.structured_goals backend.top
 

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -263,6 +263,12 @@ val commit : ?file:string -> ?include_ghost:bool -> ?include_suffix:bool
     an error occurs (queries are not part of the document). *)
 val query : t -> text:string -> (command_data, string) result
 
+(** [structured_goals d] returns the focused goals in structured form at the
+    cursor in document [d], or [None] when not in proof mode. The state is not
+    changed. *)
+val structured_goals : t
+  -> (Rocq_toplevel.structured_goal list option, string) result
+
 (** [query_text ?index d ~text] is similar to [query d ~text], but the command
     result is extracted from the feedback, and returned as a string in case of
     success. If [index] is not given, the command [text] is assumed to produce

--- a/rocq-doc-manager/lib/document.mli
+++ b/rocq-doc-manager/lib/document.mli
@@ -266,8 +266,7 @@ val query : t -> text:string -> (command_data, string) result
 (** [structured_goals d] returns the focused goals in structured form at the
     cursor in document [d], or [None] when not in proof mode. The state is not
     changed. *)
-val structured_goals : t
-  -> (Rocq_toplevel.structured_goal list option, string) result
+val structured_goals : t -> Rocq_toplevel.structured_goal list option
 
 (** [query_text ?index d ~text] is similar to [query d ~text], but the command
     result is extracted from the feedback, and returned as a string in case of

--- a/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
@@ -17,6 +17,8 @@ __all__ = [
     "CommandError",
     "CommandData",
     "ProofState",
+    "StructuredGoal",
+    "StructuredHyp",
     "GlobrefsDiff",
     "FeedbackMessage",
     "Quickfix",
@@ -176,6 +178,33 @@ class GlobrefsDiff(BaseModel):
         default_factory=list,
     )
     added_constants: list[str] = Field(
+        kw_only=True,
+        default_factory=list,
+    )
+
+
+class StructuredHyp(BaseModel):
+    """Hypothesis of a structured goal."""
+
+    type: str = Field(
+        kw_only=True,
+    )
+    defn: str | None = Field(
+        kw_only=True,
+        default=None,
+    )
+    name: str = Field(
+        kw_only=True,
+    )
+
+
+class StructuredGoal(BaseModel):
+    """Structured goal."""
+
+    goal: str = Field(
+        kw_only=True,
+    )
+    hyps: list[StructuredHyp] = Field(
         kw_only=True,
         default_factory=list,
     )
@@ -670,6 +699,18 @@ class RocqDocManagerAPI:
             return Err(result.message, data)
         return [Sentence.model_validate(v1) for v1 in result.result]
 
+    def structured_goals(
+        self,
+        cursor: int,
+    ) -> list[StructuredGoal] | None:
+        """Returns the focused goals at the cursor, or `null` when not in proof mode; does not change the state."""
+        result = self._rpc.raw_request(
+            "structured_goals",
+            [cursor],
+        )
+        assert not isinstance(result, Err)
+        return None if result.result is None else [StructuredGoal.model_validate(v1) for v1 in result.result]
+
     def whitespace_required(
         self,
         cursor: int,
@@ -1071,6 +1112,18 @@ class RocqDocManagerAPIAsync:
             data = SentenceSplitError.model_validate(result.data)
             return Err(result.message, data)
         return [Sentence.model_validate(v1) for v1 in result.result]
+
+    async def structured_goals(
+        self,
+        cursor: int,
+    ) -> list[StructuredGoal] | None:
+        """Returns the focused goals at the cursor, or `null` when not in proof mode; does not change the state."""
+        result = await self._rpc.raw_request(
+            "structured_goals",
+            [cursor],
+        )
+        assert not isinstance(result, Err)
+        return None if result.result is None else [StructuredGoal.model_validate(v1) for v1 in result.result]
 
     async def whitespace_required(
         self,

--- a/rocq-doc-manager/tests/structured_goals.t
+++ b/rocq-doc-manager/tests/structured_goals.t
@@ -90,7 +90,7 @@
       {
         "hyps": [
           { "name": "n", "type": "nat" },
-          { "name": "x", "def": "n", "type": "nat" }
+          { "name": "x", "defn": "n", "type": "nat" }
         ],
         "goal": "True"
       }

--- a/rocq-doc-manager/tests/structured_goals.t
+++ b/rocq-doc-manager/tests/structured_goals.t
@@ -1,0 +1,98 @@
+  $ export ROCQPATH="$DUNE_SOURCEROOT/_build/install/default/lib/coq/user-contrib"
+  $ export ROCQLIB="$DUNE_SOURCEROOT/_build/install/default/lib/coq"
+  $ export DUNE_CACHE=disabled
+  $ cat > test.v <<EOF
+  > Theorem demo : nat -> True.
+  > Proof.
+  >   intro n.
+  >   set (x := n).
+  > Abort.
+  > EOF
+
+  $ cat > calls.txt <<EOF
+  > load_file [0]
+  > run_step [0]
+  > run_step [0]
+  > run_step [0]
+  > run_step [0]
+  > run_step [0]
+  > run_step [0]
+  > run_step [0]
+  > structured_goals [0]
+  > EOF
+
+  $ cat calls.txt | jsonrpc-tp.build_requests | jsonrpc-tp.tp_wrap > commands.txt
+
+  $ cat commands.txt | rocq-doc-manager test.v -- -Q . test.dir | jsonrpc-tp.tp_unwrap
+  { "method": "ready_seq", "jsonrpc": "2.0" }
+  { "id": 1, "jsonrpc": "2.0", "result": null }
+  {
+    "id": 2,
+    "jsonrpc": "2.0",
+    "result": {
+      "proof_state": {
+        "given_up_goals": 0,
+        "shelved_goals": 0,
+        "focused_goals": [ "\n============================\nnat -> True" ]
+      },
+      "synterp_ast": {
+        "kind": "StartTheoremProof",
+        "pure": true,
+        "attrs": { "ids": [ "demo" ], "kind": "Theorem" }
+      }
+    }
+  }
+  { "id": 3, "jsonrpc": "2.0", "result": null }
+  {
+    "id": 4,
+    "jsonrpc": "2.0",
+    "result": {
+      "proof_state": {
+        "given_up_goals": 0,
+        "shelved_goals": 0,
+        "focused_goals": [ "\n============================\nnat -> True" ]
+      },
+      "synterp_ast": { "kind": "Proof", "pure": true, "attrs": {} }
+    }
+  }
+  { "id": 5, "jsonrpc": "2.0", "result": null }
+  {
+    "id": 6,
+    "jsonrpc": "2.0",
+    "result": {
+      "proof_state": {
+        "given_up_goals": 0,
+        "shelved_goals": 0,
+        "focused_goals": [ "\nn : nat\n============================\nTrue" ]
+      },
+      "synterp_ast": { "kind": "Extend", "attrs": {} }
+    }
+  }
+  { "id": 7, "jsonrpc": "2.0", "result": null }
+  {
+    "id": 8,
+    "jsonrpc": "2.0",
+    "result": {
+      "proof_state": {
+        "given_up_goals": 0,
+        "shelved_goals": 0,
+        "focused_goals": [
+          "\nn : nat\nx := n : nat\n============================\nTrue"
+        ]
+      },
+      "synterp_ast": { "kind": "Extend", "attrs": {} }
+    }
+  }
+  {
+    "id": 9,
+    "jsonrpc": "2.0",
+    "result": [
+      {
+        "hyps": [
+          { "name": "n", "type": "nat" },
+          { "name": "x", "def": "n", "type": "nat" }
+        ],
+        "goal": "True"
+      }
+    ]
+  }


### PR DESCRIPTION
The structure is the same as goal-to-json, but it doesn't require adding an extra call to the document.  It seems to be enough for Alectryon support.

I'm not sure this is the best approach, though (I like the minimal surface of the command language).  Perhaps it would be better for run_step itself to change its output format when given a flag? I didn't find a great way to model that within the API definition language.  Or perhaps there should be a generic "query" command that happens to support "structured_goal" as one kind of query?  It might also be relevant to think of other output formats (e.g. ppbox, which VSRocq uses by default).

Another issue is the duplication between this new command and goal-of-json (I tried to use that directly but it was much slower).  I can extract a shared plugin and make both depend on it, but I'm not sure if that's worth it.

In any case, congrats on the nice implementation, it's been very smooth to work with!