### PR TITLE
Report each command's location in `run_step`

### DIFF
--- a/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
+++ b/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
@@ -142,18 +142,25 @@ let structured_goals state =
 
 let run state off text =
   Feed.reset ();
-  try
-    let stream = Gramlib.Stream.of_string ~offset:off text in
-    let input = Procq.Parsable.make stream in
-    let entry = Pvernac.main_entry in
-    let open Vernac.State in
-    let vernac =
-      match Stm.parse_sentence ~doc:state.doc state.sid ~entry input with
-      | Some(vernac) -> vernac
-      | None         ->
-          CErrors.user_err (Pp.str "End of file, no command found in input.")
-    in
-    let _ =
+  let open Vernac.State in
+  let error ?loc e =
+    let (e, info) = Exninfo.capture e in
+    let error_loc = Loc.get_loc info in
+    let msg = Pp.string_of_ppcmds (CErrors.iprint (e, info)) in
+    let feedback_messages = Feed.collect feedback_filter in
+    (state, Error(msg, {error_loc; feedback_messages; loc}))
+  in
+  match
+    try
+      let stream = Gramlib.Stream.of_string ~offset:off text in
+      let input = Procq.Parsable.make stream in
+      let entry = Pvernac.main_entry in
+      let vernac =
+        match Stm.parse_sentence ~doc:state.doc state.sid ~entry input with
+        | Some(vernac) -> vernac
+        | None         ->
+            CErrors.user_err (Pp.str "End of file, no command found in input.")
+      in
       match vernac.CAst.loc with None -> assert false | Some(loc) ->
       (* Check for leading text. *)
       let len_leading = loc.Loc.bp - off in
@@ -169,8 +176,14 @@ let run state off text =
         let s = String.sub text len_command (len_text - len_command) in
         let msg = Printf.sprintf "Trailing text after command: %S." s in
         CErrors.user_err (Pp.str msg)
-      end
-    in
+      end;
+      Ok(vernac)
+    with e -> Error(error e)
+  with
+  | Error(result) -> result
+  | Ok(vernac) ->
+  let loc = vernac.CAst.loc in
+  try
     let env1 = Global.env () in
     let new_state = Vernac.process_expr ~state vernac in
     let env2 = Global.env () in
@@ -200,15 +213,10 @@ let run state off text =
       in
       let feedback_messages = Feed.collect feedback_filter in
       let synterp_ast = Rocq_vernac_entry.of_vernac_control vernac in
-      {globrefs_diff; feedback_messages; synterp_ast; proof_state}
+      {globrefs_diff; feedback_messages; synterp_ast; proof_state; loc}
     in
     (new_state, Ok(data))
-  with e ->
-    let (e, info) = Exninfo.capture e in
-    let error_loc = Loc.get_loc info in
-    let msg = Pp.string_of_ppcmds (CErrors.iprint (e, info)) in
-    let feedback_messages = Feed.collect feedback_filter in
-    (state, Error(msg, {error_loc; feedback_messages}))
+  with e -> error ?loc e
 
 let fork : state -> pipe_in:string -> pipe_out:string ->
     state * (int, string) result = fun state ~pipe_in ~pipe_out ->

--- a/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
+++ b/ocaml-rocq-simple-api/bin/private-toplevel/main.ml
@@ -142,7 +142,6 @@ let structured_goals state =
 
 let run state off text =
   Feed.reset ();
-  let open Vernac.State in
   let error ?loc e =
     let (e, info) = Exninfo.capture e in
     let error_loc = Loc.get_loc info in
@@ -150,38 +149,39 @@ let run state off text =
     let feedback_messages = Feed.collect feedback_filter in
     (state, Error(msg, {error_loc; feedback_messages; loc}))
   in
-  match
-    try
-      let stream = Gramlib.Stream.of_string ~offset:off text in
-      let input = Procq.Parsable.make stream in
-      let entry = Pvernac.main_entry in
-      let vernac =
-        match Stm.parse_sentence ~doc:state.doc state.sid ~entry input with
-        | Some(vernac) -> vernac
-        | None         ->
-            CErrors.user_err (Pp.str "End of file, no command found in input.")
-      in
-      match vernac.CAst.loc with None -> assert false | Some(loc) ->
-      (* Check for leading text. *)
-      let len_leading = loc.Loc.bp - off in
-      if len_leading <> 0 then begin
-        let s = String.sub text 0 len_leading in
-        let msg = Printf.sprintf "Leading text before command: %S." s in
-        CErrors.user_err (Pp.str msg)
-      end;
-      (* Check for trailing text. *)
-      let len_command = loc.Loc.ep - loc.Loc.bp in
-      let len_text = String.length text in
-      if len_command < len_text then begin
-        let s = String.sub text len_command (len_text - len_command) in
-        let msg = Printf.sprintf "Trailing text after command: %S." s in
-        CErrors.user_err (Pp.str msg)
-      end;
-      Ok(vernac)
-    with e -> Error(error e)
-  with
+  let run () =
+    let stream = Gramlib.Stream.of_string ~offset:off text in
+    let input = Procq.Parsable.make stream in
+    let entry = Pvernac.main_entry in
+    let open Vernac.State in
+    let vernac =
+      match Stm.parse_sentence ~doc:state.doc state.sid ~entry input with
+      | Some(vernac) -> vernac
+      | None         ->
+          CErrors.user_err (Pp.str "End of file, no command found in input.")
+    in
+    match vernac.CAst.loc with None -> assert false | Some(loc) ->
+    (* Check for leading text. *)
+    let len_leading = loc.Loc.bp - off in
+    if len_leading <> 0 then begin
+      let s = String.sub text 0 len_leading in
+      let msg = Printf.sprintf "Leading text before command: %S." s in
+      CErrors.user_err (Pp.str msg)
+    end;
+    (* Check for trailing text. *)
+    let len_command = loc.Loc.ep - loc.Loc.bp in
+    let len_text = String.length text in
+    if len_command < len_text then begin
+      let s = String.sub text len_command (len_text - len_command) in
+      let msg = Printf.sprintf "Trailing text after command: %S." s in
+      CErrors.user_err (Pp.str msg)
+    end;
+    Ok(vernac)
+  in
+  match run () with
+  | exception e   -> error e
   | Error(result) -> result
-  | Ok(vernac) ->
+  | Ok(vernac)    ->
   let loc = vernac.CAst.loc in
   try
     let env1 = Global.env () in

--- a/ocaml-rocq-simple-api/lib/api/rocq_toplevel.mli
+++ b/ocaml-rocq-simple-api/lib/api/rocq_toplevel.mli
@@ -102,11 +102,13 @@ type run_data = {
   feedback_messages : feedback_message list;
   synterp_ast : Rocq_vernac_entry.command;
   proof_state : proof_state option;
+  loc : Loc.t option;
 }
 
 type run_error = {
   error_loc : Loc.t option;
   feedback_messages : feedback_message list;
+  loc : Loc.t option;
 }
 
 (** [run t ~off ~text] runs the vernacular command from [text] in the toplevel

--- a/ocaml-rocq-simple-api/lib/internal/rocq_toplevel_data.ml
+++ b/ocaml-rocq-simple-api/lib/internal/rocq_toplevel_data.ml
@@ -71,13 +71,15 @@ type run_data = {
   globrefs_diff : (globrefs_diff [@default empty_globrefs_diff]);
   feedback_messages : (feedback_message list [@default []]);
   synterp_ast : Rocq_vernac_entry.command;
-  proof_state : (proof_state option [@default None])
+  proof_state : (proof_state option [@default None]);
+  loc : (Rocq_loc.t option [@default None]);
 }
 [@@deriving to_yojson]
 
 type run_error = {
   error_loc : (Rocq_loc.t option [@default None]);
   feedback_messages : (feedback_message list [@default []]);
+  loc : (Rocq_loc.t option [@default None]);
 }
 [@@deriving to_yojson]
 

--- a/ocaml-rocq-simple-api/tests/basic.t
+++ b/ocaml-rocq-simple-api/tests/basic.t
@@ -31,10 +31,30 @@
       { "level": "info", "text": "n_rec is defined" },
       { "level": "info", "text": "n_sind is defined" }
     ],
-    "synterp_ast": { "controls": [], "tag": "Inductive", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Inductive", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 40
+    }
   }
   [0] 2 > run 0 "Require Import Stdlib.ZArith.BinInt."
-  { "synterp_ast": { "controls": [], "tag": "Require", "pure": false } }
+  {
+    "synterp_ast": { "controls": [], "tag": "Require", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 36
+    }
+  }
   [0] 3 > run 0 "Require Import Stdlib.ZArith.BinIntt"
   Error: while processing the command.
   Syntax error: '.' expected after [gallina_ext] (in [vernac_aux]).
@@ -77,13 +97,31 @@
         },
         "text": "Unable to locate library\nStdlib.ZArith.BinInk (while searching for a .vos file)."
       }
-    ]
+    ],
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 36
+    }
   }
   [0] 3 > run 0 "Lemma test : 0 = 0."
   {
     "synterp_ast": { "controls": [], "tag": "StartTheoremProof", "pure": true },
     "proof_state": {
       "focused_goals": [ "\n============================\n0 = 0" ]
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 19
     }
   }
   [0] 5 > run 0 "Proof."
@@ -91,17 +129,44 @@
     "synterp_ast": { "controls": [], "tag": "Proof", "pure": true },
     "proof_state": {
       "focused_goals": [ "\n============================\n0 = 0" ]
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 6
     }
   }
   [0] 6 > run 0 "reflexivity."
   {
     "synterp_ast": { "controls": [], "tag": "Extend", "pure": false },
-    "proof_state": {}
+    "proof_state": {},
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 12
+    }
   }
   [0] 7 > run 0 "Qed."
   {
     "globrefs_diff": { "added_constants": [ "Top.test" ] },
-    "synterp_ast": { "controls": [], "tag": "EndProof", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "EndProof", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 4
+    }
   }
   [0] 8 > run 37 "About test."
   {
@@ -111,7 +176,16 @@
         "text": "test : 0 = 0\n\ntest is not universe polymorphic\ntest is opaque\nExpands to: Constant Top.test\nDeclared in toplevel input, characters 6-10"
       }
     ],
-    "synterp_ast": { "controls": [], "tag": "Print", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Print", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 37,
+      "ep": 48
+    }
   }
   [0] 9 > back_to 3
   [0] 3 > back_to 8
@@ -122,7 +196,16 @@
     "feedback_messages": [
       { "level": "notice", "text": "test not a defined object." }
     ],
-    "synterp_ast": { "controls": [], "tag": "Print", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Print", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 37,
+      "ep": 48
+    }
   }
   [0] 10 > run 37 "Fail Qed."
   {
@@ -132,7 +215,16 @@
         "text": "The command has indeed failed with message:\nCommand not supported (No proof-editing in progress)."
       }
     ],
-    "synterp_ast": { "controls": [ "Fail" ], "tag": "EndProof", "pure": true }
+    "synterp_ast": { "controls": [ "Fail" ], "tag": "EndProof", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 37,
+      "ep": 46
+    }
   }
   [0] 11 > run 37 "Time Succeed Timeout 30 About nat."
   {
@@ -150,6 +242,15 @@
       "controls": [ "Time", "Succeed", "Timeout" ],
       "tag": "Print",
       "pure": true
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 37,
+      "ep": 71
     }
   }
   [0] 12 > [EOF]

--- a/ocaml-rocq-simple-api/tests/fork.t
+++ b/ocaml-rocq-simple-api/tests/fork.t
@@ -28,7 +28,16 @@
       { "level": "info", "text": "n_rec is defined" },
       { "level": "info", "text": "n_sind is defined" }
     ],
-    "synterp_ast": { "controls": [], "tag": "Inductive", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Inductive", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 40
+    }
   }
   [0] 2 > stop 0
   Error: cannot stop the current toplevel.
@@ -47,7 +56,16 @@
         "text": "n : Set\n\nn is not universe polymorphic\nExpands to: Inductive Top.n\nDeclared in toplevel input, characters 10-11"
       }
     ],
-    "synterp_ast": { "controls": [], "tag": "Print", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Print", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 8
+    }
   }
   [1] 3 > fork 1
   New toplevel forked with identifier 2.

--- a/ocaml-rocq-simple-api/tests/leading_trailing.t
+++ b/ocaml-rocq-simple-api/tests/leading_trailing.t
@@ -38,6 +38,15 @@
     "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
     "proof_state": {
       "focused_goals": [ "\n============================\n0 = 0" ]
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 11
     }
   }
   [0] 2 > run 0 "Proof.   "
@@ -49,6 +58,15 @@
     "synterp_ast": { "controls": [], "tag": "Proof", "pure": true },
     "proof_state": {
       "focused_goals": [ "\n============================\n0 = 0" ]
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 6
     }
   }
   [0] 3 > run 127 "- reflexivity."
@@ -69,23 +87,59 @@
     "proof_state": {
       "unfocused_goals": [ 0 ],
       "focused_goals": [ "\n============================\n0 = 0" ]
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 1
     }
   }
   [0] 4 > run 0 "reflexivity."
   {
     "synterp_ast": { "controls": [], "tag": "Extend", "pure": false },
-    "proof_state": { "unfocused_goals": [ 0 ] }
+    "proof_state": { "unfocused_goals": [ 0 ] },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 12
+    }
   }
   [0] 5 > run 0 "Qed."
   {
     "globrefs_diff": { "added_constants": [ "Top.Unnamed_thm" ] },
-    "synterp_ast": { "controls": [], "tag": "EndProof", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "EndProof", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 4
+    }
   }
   [0] 6 > run 0 "Goal 0 = 0."
   {
     "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
     "proof_state": {
       "focused_goals": [ "\n============================\n0 = 0" ]
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 11
     }
   }
   [0] 7 > run 0 "Proof."
@@ -93,6 +147,15 @@
     "synterp_ast": { "controls": [], "tag": "Proof", "pure": true },
     "proof_state": {
       "focused_goals": [ "\n============================\n0 = 0" ]
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 6
     }
   }
   [0] 8 > run 0 "1:"
@@ -112,7 +175,16 @@
   [0] 8 > run 0 "1: reflexivity."
   {
     "synterp_ast": { "controls": [], "tag": "Extend", "pure": false },
-    "proof_state": {}
+    "proof_state": {},
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 15
+    }
   }
   [0] 9 > run 0 "1:{ "
   Error: while processing the command.
@@ -145,7 +217,16 @@
         },
         "text": "[Focus] No such goal (1)."
       }
-    ]
+    ],
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 3
+    }
   }
   [0] 9 > run 0 "reflexivity."
   Error: while processing the command.
@@ -174,7 +255,16 @@
         },
         "text": "No such goal."
       }
-    ]
+    ],
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 12
+    }
   }
   [0] 9 > run 246 "} "
   Error: while processing the command.
@@ -211,12 +301,30 @@
         },
         "text": "The proof is not focused"
       }
-    ]
+    ],
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 1
+    }
   }
   [0] 9 > run 0 "Qed."
   {
     "globrefs_diff": { "added_constants": [ "Top.Unnamed_thm0" ] },
-    "synterp_ast": { "controls": [], "tag": "EndProof", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "EndProof", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 4
+    }
   }
   [0] 13 > run 0 "  Locate nat."
   Error: while processing the command.

--- a/ocaml-rocq-simple-api/tests/module.t
+++ b/ocaml-rocq-simple-api/tests/module.t
@@ -16,49 +16,134 @@
     "feedback_messages": [
       { "level": "info", "text": "Interactive Module foo started" }
     ],
-    "synterp_ast": { "controls": [], "tag": "DefineModule", "pure": false }
+    "synterp_ast": { "controls": [], "tag": "DefineModule", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 11
+    }
   }
   [0] 2 > run 0 "Definition a := nat."
   {
     "globrefs_diff": { "added_constants": [ "Top.foo.a" ] },
     "feedback_messages": [ { "level": "info", "text": "a is defined" } ],
-    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 20
+    }
   }
   [0] 3 > run 0 "Module bar."
   {
     "feedback_messages": [
       { "level": "info", "text": "Interactive Module bar started" }
     ],
-    "synterp_ast": { "controls": [], "tag": "DefineModule", "pure": false }
+    "synterp_ast": { "controls": [], "tag": "DefineModule", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 11
+    }
   }
   [0] 4 > run 0 "Definition b := nat."
   {
     "globrefs_diff": { "added_constants": [ "Top.foo.bar.b" ] },
     "feedback_messages": [ { "level": "info", "text": "b is defined" } ],
-    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 20
+    }
   }
   [0] 5 > run 0 "End bar."
   {
     "feedback_messages": [
       { "level": "info", "text": "Module bar is defined" }
     ],
-    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false }
+    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 8
+    }
   }
   [0] 6 > run 0 "Section junk."
-  { "synterp_ast": { "controls": [], "tag": "BeginSection", "pure": false } }
+  {
+    "synterp_ast": { "controls": [], "tag": "BeginSection", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 13
+    }
+  }
   [0] 7 > run 0 "Definition c := nat."
   {
     "globrefs_diff": { "added_constants": [ "Top.foo.c" ] },
     "feedback_messages": [ { "level": "info", "text": "c is defined" } ],
-    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 20
+    }
   }
   [0] 8 > run 0 "End junk."
-  { "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false } }
+  {
+    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 9
+    }
+  }
   [0] 9 > run 0 "End foo."
   {
     "feedback_messages": [
       { "level": "info", "text": "Module foo is defined" }
     ],
-    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false }
+    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 8
+    }
   }
   [0] 10 > [EOF]

--- a/ocaml-rocq-simple-api/tests/module_type.t
+++ b/ocaml-rocq-simple-api/tests/module_type.t
@@ -13,13 +13,31 @@
     "feedback_messages": [
       { "level": "info", "text": "Interactive Module foo started" }
     ],
-    "synterp_ast": { "controls": [], "tag": "DefineModule", "pure": false }
+    "synterp_ast": { "controls": [], "tag": "DefineModule", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 11
+    }
   }
   [0] 2 > run 0 "Definition a := nat."
   {
     "globrefs_diff": { "added_constants": [ "Top.foo.a" ] },
     "feedback_messages": [ { "level": "info", "text": "a is defined" } ],
-    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 20
+    }
   }
   [0] 3 > run 0 "Module Type bar."
   {
@@ -30,13 +48,31 @@
       "controls": [],
       "tag": "DeclareModuleType",
       "pure": false
+    },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 16
     }
   }
   [0] 4 > run 0 "Definition b := nat."
   {
     "globrefs_diff": { "added_constants": [ "Top.foo.bar.b" ] },
     "feedback_messages": [ { "level": "info", "text": "b is defined" } ],
-    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 20
+    }
   }
   [0] 5 > run 0 "End bar."
   {
@@ -44,13 +80,31 @@
     "feedback_messages": [
       { "level": "info", "text": "Module Type bar is defined" }
     ],
-    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false }
+    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 8
+    }
   }
   [0] 6 > run 0 "End foo."
   {
     "feedback_messages": [
       { "level": "info", "text": "Module foo is defined" }
     ],
-    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false }
+    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 8
+    }
   }
   [0] 7 > [EOF]

--- a/ocaml-rocq-simple-api/tests/section.t
+++ b/ocaml-rocq-simple-api/tests/section.t
@@ -8,25 +8,74 @@
 
   $ cat commands.txt | rocq-simple-api.toplevel
   [0] 1 > run 0 "Section test."
-  { "synterp_ast": { "controls": [], "tag": "BeginSection", "pure": false } }
+  {
+    "synterp_ast": { "controls": [], "tag": "BeginSection", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 13
+    }
+  }
   [0] 2 > run 0 "Context (n : nat)."
   {
     "feedback_messages": [ { "level": "info", "text": "n is declared" } ],
-    "synterp_ast": { "controls": [], "tag": "Context", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Context", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 18
+    }
   }
   [0] 3 > run 0 "Definition get := n."
   {
     "globrefs_diff": { "added_constants": [ "Top.get" ] },
     "feedback_messages": [ { "level": "info", "text": "get is defined" } ],
-    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "Definition", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 20
+    }
   }
   [0] 4 > run 0 "End test."
-  { "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false } }
+  {
+    "synterp_ast": { "controls": [], "tag": "EndSegment", "pure": false },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 9
+    }
+  }
   [0] 5 > run 0 "Check get."
   {
     "feedback_messages": [
       { "level": "notice", "text": "get\n     : nat -> nat" }
     ],
-    "synterp_ast": { "controls": [], "tag": "CheckMayEval", "pure": true }
+    "synterp_ast": { "controls": [], "tag": "CheckMayEval", "pure": true },
+    "loc": {
+      "fname": [ "ToplevelInput" ],
+      "line_nb": 1,
+      "bol_pos": 0,
+      "line_nb_last": 1,
+      "bol_pos_last": 0,
+      "bp": 0,
+      "ep": 10
+    }
   }
   [0] 6 > [EOF]

--- a/rocq-doc-manager/README.md
+++ b/rocq-doc-manager/README.md
@@ -117,6 +117,7 @@ API Objects
 ### `CommandData`
 
 - Description: data gathered while running a Rocq command.
+- Field `loc`: source location of the command (as either `null` or an instance of the `RocqLoc` object).
 - Field `synterp_ast`: limited Rocq AST data (as an instance of the `VernacData` object).
 - Field `proof_state`: either `null` or an instance of the `ProofState` object.
 - Field `feedback_messages`: a list where each element is an instance of the `FeedbackMessage` object.
@@ -125,6 +126,7 @@ API Objects
 ### `CommandError`
 
 - Description: data returned on Rocq command errors.
+- Field `loc`: source location of the command (as either `null` or an instance of the `RocqLoc` object).
 - Field `feedback_messages`: a list where each element is an instance of the `FeedbackMessage` object.
 - Field `error_loc`: optional source code location for the error (as either `null` or an instance of the `RocqLoc` object).
 

--- a/rocq-doc-manager/bin/rocq_doc_manager.ml
+++ b/rocq-doc-manager/bin/rocq_doc_manager.ml
@@ -489,12 +489,15 @@ let command_data =
     API.Fields.add ~name:"proof_state" S.(nullable (obj proof_state)) @@
     API.Fields.add ~name:"synterp_ast" ~descr:"limited Rocq AST data"
       S.(obj vernac_data) @@
+    API.Fields.add ~name:"loc" ~descr:"source location of the command"
+      S.(nullable (obj rocq_loc)) @@
     API.Fields.nil
   in
   let open Rocq_toplevel in
   let encode _ = assert false in
-  let decode {globrefs_diff; feedback_messages; synterp_ast; proof_state} =
-    (globrefs_diff, (feedback_messages, (proof_state, (synterp_ast, ()))))
+  let decode {globrefs_diff; feedback_messages; synterp_ast; proof_state; loc} =
+    (globrefs_diff,
+      (feedback_messages, (proof_state, (synterp_ast, (loc, ())))))
   in
   API.declare_object api ~name:"CommandData"
     ~descr:"data gathered while running a Rocq command" ~encode ~decode fields
@@ -505,14 +508,16 @@ let command_error =
       for the error" S.(nullable (obj rocq_loc)) @@
     API.Fields.add ~name:"feedback_messages"
       S.(list (obj feedback_message)) @@
+    API.Fields.add ~name:"loc" ~descr:"source location of the command"
+      S.(nullable (obj rocq_loc)) @@
     API.Fields.nil
   in
   let open Rocq_toplevel in
-  let encode (error_loc, (feedback_messages, ())) =
-    {error_loc; feedback_messages}
+  let encode (error_loc, (feedback_messages, (loc, ()))) =
+    {error_loc; feedback_messages; loc}
   in
-  let decode {error_loc; feedback_messages} =
-    (error_loc, (feedback_messages, ()))
+  let decode {error_loc; feedback_messages; loc} =
+    (error_loc, (feedback_messages, (loc, ())))
   in
   API.declare_object api ~name:"CommandError"
     ~descr:"data returned on Rocq command errors" ~encode ~decode fields

--- a/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
+++ b/rocq-doc-manager/python/src/rocq_doc_manager/rocq_doc_manager_api.py
@@ -232,6 +232,11 @@ class ProofState(BaseModel):
 class CommandData(BaseModel):
     """Data gathered while running a Rocq command."""
 
+    loc: RocqLoc | None = Field(
+        kw_only=True,
+        default=None,
+        description="source location of the command",
+    )
     synterp_ast: VernacData = Field(
         kw_only=True,
         description="limited Rocq AST data",
@@ -253,6 +258,11 @@ class CommandData(BaseModel):
 class CommandError(BaseModel):
     """Data returned on Rocq command errors."""
 
+    loc: RocqLoc | None = Field(
+        kw_only=True,
+        default=None,
+        description="source location of the command",
+    )
     feedback_messages: list[FeedbackMessage] = Field(
         kw_only=True,
         default_factory=list,

--- a/rocq-doc-manager/tests/basic.t
+++ b/rocq-doc-manager/tests/basic.t
@@ -54,7 +54,17 @@
   {
     "id": 2,
     "jsonrpc": "2.0",
-    "result": { "synterp_ast": { "kind": "Require", "attrs": {} } }
+    "result": {
+      "synterp_ast": { "kind": "Require", "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 36
+      }
+    }
   }
   { "id": 3, "jsonrpc": "2.0", "result": null }
   { "id": 4, "jsonrpc": "2.0", "result": null }
@@ -70,6 +80,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "inserted", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 62,
+        "ep": 89
       }
     }
   }
@@ -84,7 +102,15 @@
           "text": "nil : forall {A : Type}, list A\n\nnil is template universe polymorphic\nArguments nil {A}%_type_scope\nExpands to: Constructor Corelib.Init.Datatypes.nil\nDeclared in library Corelib.Init.Datatypes, line 328, characters 3-6"
         }
       ],
-      "synterp_ast": { "kind": "Print", "pure": true, "attrs": {} }
+      "synterp_ast": { "kind": "Print", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 90,
+        "ep": 100
+      }
     }
   }
   { "id": 8, "jsonrpc": "2.0", "result": null }
@@ -98,6 +124,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "junk", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 4,
+        "bol_pos_last": 126,
+        "bp": 105,
+        "ep": 130
       }
     }
   }
@@ -109,7 +143,15 @@
       "feedback_messages": [
         { "level": "notice", "text": "12 < 42 <= 100\n     : Prop" }
       ],
-      "synterp_ast": { "kind": "CheckMayEval", "pure": true, "attrs": {} }
+      "synterp_ast": { "kind": "CheckMayEval", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 131,
+        "ep": 152
+      }
     }
   }
   {
@@ -222,6 +264,14 @@
         "kind": "StartTheoremProof",
         "pure": true,
         "attrs": { "ids": [ "test" ], "kind": "Theorem" }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 155,
+        "ep": 192
       }
     }
   }
@@ -237,7 +287,15 @@
           "\n============================\nforall x : nat, x = x"
         ]
       },
-      "synterp_ast": { "kind": "Proof", "pure": true, "attrs": {} }
+      "synterp_ast": { "kind": "Proof", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 193,
+        "ep": 199
+      }
     }
   }
   { "id": 18, "jsonrpc": "2.0", "result": null }
@@ -250,7 +308,15 @@
         "shelved_goals": 0,
         "focused_goals": [ "\nx : nat\n============================\nx = x" ]
       },
-      "synterp_ast": { "kind": "Extend", "attrs": {} }
+      "synterp_ast": { "kind": "Extend", "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 202,
+        "ep": 210
+      }
     }
   }
   { "id": 20, "jsonrpc": "2.0", "result": null }
@@ -259,7 +325,15 @@
     "jsonrpc": "2.0",
     "result": {
       "proof_state": { "given_up_goals": 0, "shelved_goals": 0 },
-      "synterp_ast": { "kind": "Extend", "attrs": {} }
+      "synterp_ast": { "kind": "Extend", "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 213,
+        "ep": 225
+      }
     }
   }
   { "id": 22, "jsonrpc": "2.0", "result": null }
@@ -272,6 +346,14 @@
         "kind": "EndProof",
         "pure": true,
         "attrs": { "kind": "Qed" }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 226,
+        "ep": 230
       }
     }
   }

--- a/rocq-doc-manager/tests/cursor.t
+++ b/rocq-doc-manager/tests/cursor.t
@@ -41,6 +41,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "test1", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 24
       }
     }
   }
@@ -57,6 +65,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "test2", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 25,
+        "ep": 49
       }
     }
   }
@@ -73,6 +89,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "test3", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 50,
+        "ep": 74
       }
     }
   }

--- a/rocq-doc-manager/tests/cursors.t
+++ b/rocq-doc-manager/tests/cursors.t
@@ -40,6 +40,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "x1", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 18,
+        "ep": 39
       }
     }
   }
@@ -74,6 +82,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "inserted", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 63,
+        "ep": 90
       }
     }
   }

--- a/rocq-doc-manager/tests/query.t
+++ b/rocq-doc-manager/tests/query.t
@@ -77,6 +77,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "_", "kind": "Definition", "proof": true }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 10
       }
     }
   }
@@ -91,5 +99,15 @@
   {
     "id": 9,
     "jsonrpc": "2.0",
-    "result": { "synterp_ast": { "kind": "Abort", "pure": true, "attrs": {} } }
+    "result": {
+      "synterp_ast": { "kind": "Abort", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 6
+      }
+    }
   }

--- a/rocq-doc-manager/tests/replace_suffix.t
+++ b/rocq-doc-manager/tests/replace_suffix.t
@@ -69,6 +69,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "test4", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 22
       }
     }
   }
@@ -120,6 +128,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "my_test", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 23,
+        "ep": 55
       }
     }
   }
@@ -175,6 +191,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "foo", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 20
       }
     }
   }

--- a/rocq-doc-manager/tests/revert.t
+++ b/rocq-doc-manager/tests/revert.t
@@ -66,6 +66,14 @@
         "kind": "Definition",
         "pure": true,
         "attrs": { "id": "test", "kind": "Definition", "proof": false }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 23
       }
     }
   }
@@ -80,7 +88,15 @@
           "text": "nat : Set\n\nnat is not universe polymorphic\nExpands to: Inductive Corelib.Init.Datatypes.nat\nDeclared in library Corelib.Init.Datatypes, line 187, characters 10-13"
         }
       ],
-      "synterp_ast": { "kind": "Print", "pure": true, "attrs": {} }
+      "synterp_ast": { "kind": "Print", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 24,
+        "ep": 34
+      }
     }
   }
   {
@@ -151,7 +167,15 @@
       "feedback_messages": [
         { "level": "notice", "text": "test\n     : Set" }
       ],
-      "synterp_ast": { "kind": "CheckMayEval", "pure": true, "attrs": {} }
+      "synterp_ast": { "kind": "CheckMayEval", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 35,
+        "ep": 46
+      }
     }
   }
   { "id": 13, "jsonrpc": "2.0", "result": null }

--- a/rocq-doc-manager/tests/sentence_split.t
+++ b/rocq-doc-manager/tests/sentence_split.t
@@ -45,6 +45,14 @@
         "kind": "StartTheoremProof",
         "pure": true,
         "attrs": { "ids": [ "refl" ], "kind": "Theorem" }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 40
       }
     }
   }
@@ -60,7 +68,15 @@
           "\nX : Type\nx : X\n============================\nx = x"
         ]
       },
-      "synterp_ast": { "kind": "Proof", "pure": true, "attrs": {} }
+      "synterp_ast": { "kind": "Proof", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 41,
+        "ep": 47
+      }
     }
   }
   { "id": 5, "jsonrpc": "2.0", "result": null }
@@ -203,7 +219,15 @@
           "\nX : Type\nx : X\n============================\nx = x"
         ]
       },
-      "synterp_ast": { "kind": "Extend", "attrs": {} }
+      "synterp_ast": { "kind": "Extend", "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 66,
+        "ep": 72
+      }
     }
   }
   {

--- a/rocq-doc-manager/tests/structured_goals.t
+++ b/rocq-doc-manager/tests/structured_goals.t
@@ -36,6 +36,14 @@
         "kind": "StartTheoremProof",
         "pure": true,
         "attrs": { "ids": [ "demo" ], "kind": "Theorem" }
+      },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 0,
+        "ep": 27
       }
     }
   }
@@ -49,7 +57,15 @@
         "shelved_goals": 0,
         "focused_goals": [ "\n============================\nnat -> True" ]
       },
-      "synterp_ast": { "kind": "Proof", "pure": true, "attrs": {} }
+      "synterp_ast": { "kind": "Proof", "pure": true, "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 28,
+        "ep": 34
+      }
     }
   }
   { "id": 5, "jsonrpc": "2.0", "result": null }
@@ -62,7 +78,15 @@
         "shelved_goals": 0,
         "focused_goals": [ "\nn : nat\n============================\nTrue" ]
       },
-      "synterp_ast": { "kind": "Extend", "attrs": {} }
+      "synterp_ast": { "kind": "Extend", "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 37,
+        "ep": 45
+      }
     }
   }
   { "id": 7, "jsonrpc": "2.0", "result": null }
@@ -77,7 +101,15 @@
           "\nn : nat\nx := n : nat\n============================\nTrue"
         ]
       },
-      "synterp_ast": { "kind": "Extend", "attrs": {} }
+      "synterp_ast": { "kind": "Extend", "attrs": {} },
+      "loc": {
+        "line_nb": 1,
+        "bol_pos": 0,
+        "line_nb_last": 1,
+        "bol_pos_last": 0,
+        "bp": 48,
+        "ep": 61
+      }
     }
   }
   {

--- a/rocq-pipeline/tests/task_mod.t/run.t
+++ b/rocq-pipeline/tests/task_mod.t/run.t
@@ -47,7 +47,7 @@
   > EOF
 
   $ rat run --agent $TESTDIR/puppet.py:puppet_builder --task-file tasks_without_mod.yaml -- 'About foo.'
-  synterp_ast=VernacData(attrs={}, pure=True, controls=[], kind='Print') proof_state=ProofState(focused_goals=['\n============================\nTrue'], unfocused_goals=[], shelved_goals=0, given_up_goals=0) feedback_messages=[FeedbackMessage(text='foo : nat\n\nfoo is not universe polymorphic\nfoo is transparent\nExpands to: Constant test.foo\nDeclared in toplevel input, characters 11-14', quickfix=[], loc=None, level='notice')] globrefs_diff=GlobrefsDiff(removed_inductives=[], added_inductives=[], removed_constants=[], added_constants=[])
+  loc=RocqLoc(ep=64, bp=54, bol_pos_last=0, line_nb_last=1, bol_pos=0, line_nb=1, fname=None) synterp_ast=VernacData(attrs={}, pure=True, controls=[], kind='Print') proof_state=ProofState(focused_goals=['\n============================\nTrue'], unfocused_goals=[], shelved_goals=0, given_up_goals=0) feedback_messages=[FeedbackMessage(text='foo : nat\n\nfoo is not universe polymorphic\nfoo is transparent\nExpands to: Constant test.foo\nDeclared in toplevel input, characters 11-14', quickfix=[], loc=None, level='notice')] globrefs_diff=GlobrefsDiff(removed_inductives=[], added_inductives=[], removed_constants=[], added_constants=[])
   dummy#dummy#test.v#Lemma:lem1: PuppetAgent gave up with message: completed 
   interactions
   
@@ -56,7 +56,7 @@
 
 
   $ rat run --agent $TESTDIR/puppet.py:puppet_builder --task-file tasks_with_mod.yaml -- 'About foo.'
-  synterp_ast=VernacData(attrs={}, pure=True, controls=[], kind='Print') proof_state=ProofState(focused_goals=['\n============================\nTrue'], unfocused_goals=[], shelved_goals=0, given_up_goals=0) feedback_messages=[FeedbackMessage(text='foo : nat\n\nfoo is not universe polymorphic\nfoo is opaque but may be made transparent\nExpands to: Constant test.foo\nDeclared in toplevel input, characters 11-14', quickfix=[], loc=None, level='notice')] globrefs_diff=GlobrefsDiff(removed_inductives=[], added_inductives=[], removed_constants=[], added_constants=[])
+  loc=RocqLoc(ep=64, bp=54, bol_pos_last=0, line_nb_last=1, bol_pos=0, line_nb=1, fname=None) synterp_ast=VernacData(attrs={}, pure=True, controls=[], kind='Print') proof_state=ProofState(focused_goals=['\n============================\nTrue'], unfocused_goals=[], shelved_goals=0, given_up_goals=0) feedback_messages=[FeedbackMessage(text='foo : nat\n\nfoo is not universe polymorphic\nfoo is opaque but may be made transparent\nExpands to: Constant test.foo\nDeclared in toplevel input, characters 11-14', quickfix=[], loc=None, level='notice')] globrefs_diff=GlobrefsDiff(removed_inductives=[], added_inductives=[], removed_constants=[], added_constants=[])
   dummy#dummy#test.v#Lemma:lem1: PuppetAgent gave up with message: completed 
   interactions
   
@@ -66,7 +66,7 @@
 
   $ rat run --agent $TESTDIR/puppet.py:puppet_builder --task-file tasks_without_mod.yaml \
   >    --task-mod '{"insert_command": {"commands": ["Opaque foo."], "ghost": true}}' -- 'About foo.'
-  synterp_ast=VernacData(attrs={}, pure=True, controls=[], kind='Print') proof_state=ProofState(focused_goals=['\n============================\nTrue'], unfocused_goals=[], shelved_goals=0, given_up_goals=0) feedback_messages=[FeedbackMessage(text='foo : nat\n\nfoo is not universe polymorphic\nfoo is opaque but may be made transparent\nExpands to: Constant test.foo\nDeclared in toplevel input, characters 11-14', quickfix=[], loc=None, level='notice')] globrefs_diff=GlobrefsDiff(removed_inductives=[], added_inductives=[], removed_constants=[], added_constants=[])
+  loc=RocqLoc(ep=64, bp=54, bol_pos_last=0, line_nb_last=1, bol_pos=0, line_nb=1, fname=None) synterp_ast=VernacData(attrs={}, pure=True, controls=[], kind='Print') proof_state=ProofState(focused_goals=['\n============================\nTrue'], unfocused_goals=[], shelved_goals=0, given_up_goals=0) feedback_messages=[FeedbackMessage(text='foo : nat\n\nfoo is not universe polymorphic\nfoo is opaque but may be made transparent\nExpands to: Constant test.foo\nDeclared in toplevel input, characters 11-14', quickfix=[], loc=None, level='notice')] globrefs_diff=GlobrefsDiff(removed_inductives=[], added_inductives=[], removed_constants=[], added_constants=[])
   dummy#dummy#test.v#Lemma:lem1: PuppetAgent gave up with message: completed 
   interactions
   


### PR DESCRIPTION
Currently my Alectryon implementation on top of rocq-agent-toolkit needs to count offsets by measuring the length of each sentence one by one.  It would be a lot nicer to get sentence location directly.