### PR TITLE
Better error-handling in [rocq-split].

### DIFF
--- a/ocaml-rocq-simple-api/lib/api/rocq_split.ml
+++ b/ocaml-rocq-simple-api/lib/api/rocq_split.ml
@@ -98,11 +98,14 @@ let run : config -> res = fun config ->
   | Ok(dirpath)    ->
       let sentences = get_sentences config res.commands None in
       Ok({dirpath; sentences})
-  | Error(s, None) ->
-      assert (res.commands = []);
-      Error(s, {parsed_sentences = []; error_loc = None})
   | Error(s, loc ) ->
-      let parsed_sentences = get_sentences config res.commands loc in
+      (* The [loc] can be [None] in two cases: (1) on an initialization error,
+         or (2) on Rocq errors that don't have a location (e.g., bad vo). *)
+      let parsed_sentences =
+        match res.commands with
+        | []   -> [] (* Load-bearing if the input file does not exist. *)
+        | cmds -> get_sentences config cmds loc
+      in
       Error(s, {parsed_sentences; error_loc = loc})
 
 let split_file : file:string -> args:string list -> res = fun ~file ~args ->

--- a/ocaml-rocq-simple-api/tests/split/bad-vo.t
+++ b/ocaml-rocq-simple-api/tests/split/bad-vo.t
@@ -1,0 +1,40 @@
+Build an Rocq source file to produce a vo.
+
+  $ touch stale.v
+  $ rocq c -Q . test.dir stale.v
+
+Change the version number to 50.0.0 so that it looks stale.
+
+  $ od -Ax -tx1z stale.vo | grep "^000000"
+  000000 43 6f 71 21 00 01 60 bb 00 00 00 00 00 00 01 64  >Coq!..`........d<
+  $ printf '\x00\x07\xa1\x20' | dd of=stale.vo bs=1 seek=4 conv=notrunc status=none
+  $ od -Ax -tx1z stale.vo | grep "^000000"
+  000000 43 6f 71 21 00 07 a1 20 00 00 00 00 00 00 01 64  >Coq!... .......d<
+
+Split a test-file that imports the stale vo file.
+
+  $ cat > test.v <<EOF
+  > About nat.
+  > Require Import test.dir.stale.
+  > EOF
+
+  $ rocq-split test.v -- -Q . test.dir
+  {
+    "error": "Error when parsing .vo (from file $TESTCASE_ROOT/stale.vo) for library test.dir.stale: File $TESTCASE_ROOT/stale.vo\nhas bad version number 500000 (expected 90299). It is corrupted or was\ncompiled with another version of Rocq.",
+    "loc": null,
+    "Items": [
+      {
+        "kind": { "controls": [], "tag": "Print", "pure": true },
+        "text": "About nat.",
+        "bp": 0,
+        "ep": 10
+      },
+      {
+        "kind": "blanks",
+        "text": "\nRequire Import test.dir.stale.\n",
+        "bp": 10,
+        "ep": 42
+      }
+    ]
+  }
+  [1]

--- a/ocaml-rocq-simple-api/tests/split/non-existent.t
+++ b/ocaml-rocq-simple-api/tests/split/non-existent.t
@@ -1,0 +1,7 @@
+  $ rocq-split non_existent.v -- -Q . test.dir
+  {
+    "error": "System error: \"non_existent.v: No such file or directory\"",
+    "loc": null,
+    "Items": []
+  }
+  [1]


### PR DESCRIPTION
Some Rocq internal errors don't have a location, so the assumption that no error location meant an initialization error was false.

Fixes #355.